### PR TITLE
Add JSDoc support for os and std modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.12.0]
+* refactor: add *JSDoc* support for `os` and `std` modules
+* refactor: replace `os` and `std` imports with `./os.js` and `./std.js` to get completion
+* refactor: ensure `// @ts-check` is set in `.js` files
+* feat: add `notNull` function to simulate `!` typescript operator (*non-null* assertion) (`types.js`)
+
 ## [0.11.0]
 * refactor: improve *JSDoc* support (`ssh.js`)
 * fix: throw an error when no value was provided for a validator which can be defined multiple times (`arg.js`)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A set of pure JS extensions for [QuickJS](https://github.com/ctn-malone/quickjs-
 * interact with [pass](https://www.passwordstore.org/) (see [doc](doc/password-store.md))
 * build glamorous shell scripts using [gum](https://github.com/charmbracelet/gum) (see [doc](doc/gum.md))
 
+<u>NB</u>: all extensions as well as `os` and `std` modules have typing through *JSDoc*
+
 # Rational
 
 I'm focused on building static binaries targeting linux command line. This library is an intent at providing just enough to make creating static adhoc scripts easier on linux. This library is for you if you're interested in doing one of the following
@@ -45,11 +47,13 @@ nix run github:ctn-malone/qjs-ext-lib#qjsc
 
 Inside the Nix shell, any `.js` file from the library can be imported from an `ext` directory
 
+<u>NB</u>: it's recommended to run `qel-symlink.sh` to create a symlink and get completion through *JSDoc*
+
 ```js
 import { curlRequest } from 'ext/curl.js';
 
 /*
-    Perform a POST request to https://jsonplaceholder.typicode.com/posts and print response payload
+  Perform a POST request to https://jsonplaceholder.typicode.com/posts and print response payload
  */
 
 const main = async () => {
@@ -88,7 +92,7 @@ Above command will do the following
 ## Execute external processes
 
 ```js
-import { exec } from './src/process.js';
+import { exec } from 'ext/process.js';
 
 /*
   Run 3 external commands in parallel 
@@ -111,7 +115,7 @@ See more [examples](examples/process)
 ## Perform REST calls
 
 ```js
-import { curlRequest } from './src/curl.js';
+import { curlRequest } from 'ext/curl.js';
 
 /*
   Perform a POST request to https://jsonplaceholder.typicode.com/posts and print response payload
@@ -137,8 +141,8 @@ See more [examples](examples/curl)
 ## Execute remote command through SSH
 
 ```js
-import * as std from 'std';
-import { Ssh } from './src/ssh.js';
+import * as std from 'ext/std.js';
+import { Ssh } from 'ext/ssh.js';
 
 /* 
   Run 'uptime' through SSH
@@ -162,7 +166,7 @@ See more [examples](examples/ssh)
 ## Parse command-line arguments
 
 ```js
-import arg from './src/arg.js';
+import arg from 'ext/arg.js';
 
 /*
   Say hello

--- a/bootstrap/bootstrap.js
+++ b/bootstrap/bootstrap.js
@@ -1,10 +1,8 @@
 /** @format */
 // @ts-check
 
-// @ts-ignore
-import * as std from 'std';
-// @ts-ignore
-import * as os from 'os';
+import * as std from './ext/std.js';
+import * as os from './ext/os.js';
 
 import arg from './ext/arg.js';
 import * as ui from './lib/ui.js';
@@ -53,8 +51,16 @@ const args = arg
   });
 
 const repoRoot = ui.ensureGitRepo(args['--dir']);
-const configPath = ui.ensureConfig(repoRoot, templatesRootDir);
-const script = ui.addScript(repoRoot, configPath, templatesRootDir, extDir);
+const configPath = ui.ensureConfig(
+  repoRoot,
+  /** @type {string} */ (templatesRootDir)
+);
+const script = ui.addScript(
+  repoRoot,
+  configPath,
+  /** @type {string} */ (templatesRootDir),
+  /** @type {string} */ (extDir)
+);
 
 const scriptPath = ui.getScriptPath(repoRoot, script.file);
 const scriptRelativePath = getRelativePath(scriptPath, curDir);

--- a/bootstrap/lib/config.js
+++ b/bootstrap/lib/config.js
@@ -1,8 +1,7 @@
 /** @format */
 // @ts-check
 
-// @ts-ignore
-import * as std from 'std';
+import * as std from '../ext/std.js';
 import { writeFile } from './utils.js';
 
 export const CONFIG_FILE_NAME = 'qel.config.json';
@@ -73,7 +72,7 @@ export const loadConfig = (configPath) => {
   /** @type {Config} */
   let config;
   try {
-    config = JSON.parse(configFile.readAsString());
+    config = JSON.parse(/** @type {std.StdFile} */ (configFile).readAsString());
   } catch (e) {
     throw new Error(`Invalid config '${configPath}' (invalid json)`);
   }
@@ -110,7 +109,7 @@ export const addScript = (config, scriptName, options) => {
   if (!config.scripts.length) {
     newScript.default = true;
   }
-  newScript.runtimeDeps = [...runtimeDeps ?? []];
+  newScript.runtimeDeps = [...(runtimeDeps ?? [])];
   config.scripts.push(newScript);
   return newScript;
 };

--- a/bootstrap/lib/flake.js
+++ b/bootstrap/lib/flake.js
@@ -1,8 +1,7 @@
 /** @format */
 // @ts-check
 
-// @ts-ignore
-import * as std from 'std';
+import * as std from '../ext/std.js';
 import { writeFile } from './utils.js';
 import { execSync } from '../ext/process.js';
 
@@ -27,10 +26,10 @@ export const createMainFlake = (flakePath, templatePath, flakeDescription) => {
       )})`
     );
   }
-  const template = templateFile
+  const template = /** @type {std.StdFile} */ (templateFile)
     .readAsString()
     .replace('@flake_description@', flakeDescription);
-  templateFile.close();
+  /** @type {std.StdFile} */ (templateFile).close();
 
   writeFile(flakePath, template);
 };
@@ -83,8 +82,8 @@ export const createQelFlake = (flakePath, templatePath) => {
       )})`
     );
   }
-  const template = templateFile.readAsString();
-  templateFile.close();
+  const template = /** @type {std.StdFile} */ (templateFile).readAsString();
+  /** @type {std.StdFile} */ (templateFile).close();
 
   writeFile(flakePath, template);
 };

--- a/bootstrap/lib/ui.js
+++ b/bootstrap/lib/ui.js
@@ -1,10 +1,8 @@
 /** @format */
 // @ts-check
 
-// @ts-ignore
-import * as std from 'std';
-// @ts-ignore
-import * as os from 'os';
+import * as std from '../ext/std.js';
+import * as os from '../ext/os.js';
 
 import * as git from './git.js';
 import * as style from './style.js';
@@ -502,7 +500,7 @@ export const addScript = (repoRoot, configPath, templatesRootDir, extDir) => {
     );
     return abort(1);
   }
-  const content = std.loadFile(templatePath);
+  const content = /** @type {string} */ (std.loadFile(templatePath));
   try {
     writeFile(scriptPath, content);
     git.addEntries(repoRoot, [scriptPath]);

--- a/bootstrap/lib/utils.js
+++ b/bootstrap/lib/utils.js
@@ -1,10 +1,8 @@
 /** @format */
 // @ts-check
 
-// @ts-ignore
-import * as std from 'std';
-
-import * as os from 'os';
+import * as std from '../ext/std.js';
+import * as os from '../ext/os.js';
 
 /**
  * @param {number} exitCode
@@ -40,8 +38,8 @@ export const writeFile = (filePath, content) => {
       `Could not open '${filePath}' for writing (${std.strerror(errObj.errno)})`
     );
   }
-  file.puts(content);
-  file.close();
+  /** @type {std.StdFile} */ (file).puts(content);
+  /** @type {std.StdFile} */ (file).close();
 };
 
 /**

--- a/bootstrap/templates/js/arg.js
+++ b/bootstrap/templates/js/arg.js
@@ -1,8 +1,7 @@
 /** @format */
 // @ts-check
 
-// @ts-ignore
-import * as std from 'std';
+import * as std from './ext/std.js';
 
 import arg from './ext/arg.js';
 
@@ -46,8 +45,8 @@ if (args['--output'] === '-') {
   std.out.puts(`${formattedContent}\n`);
 } else {
   const file = std.open(args['--output'], 'w');
-  file.puts(formattedContent);
-  file.close();
+  /** @type {std.StdFile} */ (file).puts(formattedContent);
+  /** @type {std.StdFile} */ (file).close();
   if (!args['--quiet']) {
     std.err.puts(
       `Formatted content successfully written to ${args['--output']}`

--- a/bootstrap/templates/js/arg_curl.js
+++ b/bootstrap/templates/js/arg_curl.js
@@ -1,8 +1,7 @@
 /** @format */
 // @ts-check
 
-// @ts-ignore
-import * as std from 'std';
+import * as std from './ext/std.js';
 
 import arg from './ext/arg.js';
 import { curlRequest } from './ext/curl.js';

--- a/bootstrap/templates/js/arg_curl_gum.js
+++ b/bootstrap/templates/js/arg_curl_gum.js
@@ -1,8 +1,7 @@
 /** @format */
 // @ts-check
 
-// @ts-ignore
-import * as std from 'std';
+import * as std from './ext/std.js';
 
 import arg from './ext/arg.js';
 import { curlRequest } from './ext/curl.js';

--- a/bootstrap/templates/js/arg_gum.js
+++ b/bootstrap/templates/js/arg_gum.js
@@ -1,8 +1,7 @@
 /** @format */
 // @ts-check
 
-// @ts-ignore
-import * as std from 'std';
+import * as std from './ext/std.js';
 
 import arg from './ext/arg.js';
 import { exec } from './ext/process.js';

--- a/bootstrap/templates/js/curl.js
+++ b/bootstrap/templates/js/curl.js
@@ -1,8 +1,7 @@
 /** @format */
 // @ts-check
 
-// @ts-ignore
-import * as std from 'std';
+import * as std from './ext/std.js';
 
 import { curlRequest } from './ext/curl.js';
 

--- a/bootstrap/templates/js/curl_gum.js
+++ b/bootstrap/templates/js/curl_gum.js
@@ -1,8 +1,7 @@
 /** @format */
 // @ts-check
 
-// @ts-ignore
-import * as std from 'std';
+import * as std from './ext/std.js';
 
 import { curlRequest } from './ext/curl.js';
 import * as gum from './ext/gum.js';

--- a/bootstrap/templates/js/default.js
+++ b/bootstrap/templates/js/default.js
@@ -1,7 +1,5 @@
 /** @format */
 // @ts-check
 
-// @ts-ignore
-import * as std from 'std';
-// @ts-ignore
-import * as os from 'os';
+import * as std from './ext/std.js';
+import * as os from './ext/os.js';

--- a/bootstrap/templates/js/gum.js
+++ b/bootstrap/templates/js/gum.js
@@ -1,8 +1,7 @@
 /** @format */
 // @ts-check
 
-// @ts-ignore
-import * as std from 'std';
+import * as std from './ext/std.js';
 
 import * as gum from './ext/gum.js';
 

--- a/examples/curl/example1.js
+++ b/examples/curl/example1.js
@@ -1,4 +1,5 @@
 /** @format */
+// @ts-check
 
 import { curlRequest } from '../../src/curl.js';
 

--- a/examples/curl/example2.js
+++ b/examples/curl/example2.js
@@ -1,4 +1,5 @@
 /** @format */
+// @ts-check
 
 import { Curl, multiCurl } from '../../src/curl.js';
 

--- a/examples/gum/example1.js
+++ b/examples/gum/example1.js
@@ -1,8 +1,7 @@
 /** @format */
 // @ts-check
 
-// @ts-ignore
-import * as std from 'std';
+import * as std from '../../src/std.js';
 
 import { wait } from '../../src/timers.js';
 import * as gum from '../../src/gum.js';
@@ -189,7 +188,6 @@ const askIfLikeBubbleGum = async () => {
 
   await gum.spin(wait(2000), {
     spinner: gum.Spinner.PULSE,
-    // @ts-ignore
     title: `Chewing some ${gum.style(flavor, {
       foreground: '#04B575',
     })} bubble gum...`,

--- a/examples/gum/example2.js
+++ b/examples/gum/example2.js
@@ -1,27 +1,11 @@
 /** @format */
 // @ts-check
 
-// @ts-ignore
-import * as std from 'std';
+import * as std from '../../src/std.js';
 
 import { execSync } from '../../src/process.js';
 import * as gum from '../../src/gum.js';
-
-/**
- * JSDoc types lack a non-null assertion.
- * https://github.com/Microsoft/TypeScript/issues/23405#issuecomment-873331031
- *
- * @format
- * @template T
- * @param {T} value
- */
-export const notNull = (value) => {
-  // Use `==` to check for both null and undefined
-  if (value == null) {
-    throw new Error(`Did not expect value to be null or undefined`);
-  }
-  return value;
-};
+import { notNull } from '../../src/types.js';
 
 /*
   Heavily inspired by https://github.com/charmbracelet/gum/blob/main/examples/git-branch-manager.sh

--- a/examples/process/example1.js
+++ b/examples/process/example1.js
@@ -1,4 +1,5 @@
 /** @format */
+// @ts-check
 
 import { exec } from '../../src/process.js';
 

--- a/examples/process/example2.js
+++ b/examples/process/example2.js
@@ -1,4 +1,5 @@
 /** @format */
+// @ts-check
 
 import { exec } from '../../src/process.js';
 

--- a/examples/process/example3.js
+++ b/examples/process/example3.js
@@ -1,4 +1,5 @@
 /** @format */
+// @ts-check
 
 import { Process } from '../../src/process.js';
 

--- a/examples/ssh/example1.js
+++ b/examples/ssh/example1.js
@@ -1,4 +1,5 @@
 /** @format */
+// @ts-check
 
 import { Ssh, multiSsh } from '../../src/ssh.js';
 

--- a/examples/ssh/example2.js
+++ b/examples/ssh/example2.js
@@ -1,8 +1,8 @@
 /** @format */
+// @ts-check
 
 import { Ssh } from '../../src/ssh.js';
-import * as std from 'std';
-import * as os from 'os';
+import * as std from '../../src/std.js';
 
 /*
   Setup local port forwarding through 2 servers

--- a/examples/tester/example1.js
+++ b/examples/tester/example1.js
@@ -1,4 +1,5 @@
 /** @format */
+// @ts-check
 
 import { tester } from '../../src/tester.js';
 

--- a/src/arg.js
+++ b/src/arg.js
@@ -2,12 +2,11 @@
 // @ts-check
 'use strict;';
 
-// @ts-ignore
-import * as os from 'os';
-// @ts-ignore
-import * as std from 'std';
+import * as os from './os.js';
+import * as std from './std.js';
 
 import * as path from './path.js';
+import { notNull } from './types.js';
 
 /*
   Based on https://github.com/vercel/arg/tree/5.0.0
@@ -200,11 +199,9 @@ class ArgError extends Error {
  * @return {number|undefined}
  */
 const getTtyWidth = () => {
-  // @ts-ignore
   if (!os.isatty(std.err.fileno())) {
     return;
   }
-  // @ts-ignore
   const arr = os.ttyGetWinSize(std.err.fileno());
   if (!arr) {
     return;
@@ -955,6 +952,9 @@ const splitParagraph = (paragraph, maxLength) => {
  * @returns {string|undefined}
  */
 const getValueFromEnv = (varName) => {
+  if (varName === undefined) {
+    return undefined;
+  }
   return std.getenv(varName);
 };
 
@@ -1940,7 +1940,6 @@ class PathArgValidator extends BaseStringArgValidator {
    */
   ensure() {
     this.setValidator(ValueValidatorType.ENSURE_PATH, (value) => {
-      // @ts-ignore
       if (this._checkPath(value, this._isDir)) {
         return;
       }
@@ -1958,7 +1957,6 @@ class PathArgValidator extends BaseStringArgValidator {
           `could not create parent directory - errCode: ${errCode}`
         );
       }
-      // @ts-ignore
       const fd = os.open(value, os.O_CREAT);
       if (fd < 0) {
         throw new Error(`could not create file - errCode: ${-fd}`);
@@ -1976,7 +1974,6 @@ class PathArgValidator extends BaseStringArgValidator {
   ensureParent() {
     this.setValidator(ValueValidatorType.ENSURE_PARENT_DIR, (value) => {
       const parentDir = this._getParentDir(value);
-      // @ts-ignore
       if (this._checkPath(parentDir, true)) {
         return;
       }
@@ -2034,7 +2031,6 @@ class PathArgValidator extends BaseStringArgValidator {
     let parentDir;
     const arr = entry.split('/');
     if (1 === arr.length) {
-      // @ts-ignore
       parentDir = os.getcwd()[0];
     } else {
       arr.pop();
@@ -2051,13 +2047,11 @@ class PathArgValidator extends BaseStringArgValidator {
    * @returns {boolean}
    */
   _checkPath(entry, isDir) {
-    // @ts-ignore
     const [obj, err] = os.stat(entry);
     if (err) {
       return false;
     }
-    // @ts-ignore
-    if (isDir && (obj.mode & os.S_IFDIR) !== os.S_IFDIR) {
+    if (isDir && (notNull(obj).mode & os.S_IFDIR) !== os.S_IFDIR) {
       return false;
     }
     return true;
@@ -2082,7 +2076,6 @@ class PathArgValidator extends BaseStringArgValidator {
       break;
     }
     for (const dir of dirs) {
-      // @ts-ignore
       const errCode = os.mkdir(dir);
       if (errCode < 0) {
         return -errCode;

--- a/src/curl.js
+++ b/src/curl.js
@@ -8,10 +8,8 @@
 
 import { Process } from './process.js';
 
-// @ts-ignore
-import * as os from 'os';
-// @ts-ignore
-import * as std from 'std';
+import * as os from './os.js';
+import * as std from './std.js';
 
 // in case of timeout, curl process will exit with this error code
 const CURL_ERR_TIMEOUT = 28;
@@ -648,7 +646,7 @@ class Curl {
     else if (undefined !== this._outputFile) {
       // in case of conditional output, pass a temporary file as stdout to process
       if (this._outputFile.conditionalOutput) {
-        conditionalOutputTmpFile = std.tmpfile();
+        conditionalOutputTmpFile = /** @type {std.StdFile} */ (std.tmpfile());
         processOpt.stdout = conditionalOutputTmpFile.fileno();
       }
     }
@@ -849,7 +847,6 @@ class Curl {
     if (this._isBeingCancelled) {
       return true;
     }
-    // @ts-ignore
     let signal = os.SIGINT;
     if (undefined !== opt && undefined !== opt.signal) {
       signal = opt.signal;

--- a/src/gum.js
+++ b/src/gum.js
@@ -11,10 +11,8 @@
   - >= 0.12.0
  */
 
-// @ts-ignore
-import * as os from 'os';
-// @ts-ignore
-import * as std from 'std';
+import * as os from './os.js';
+import * as std from './std.js';
 
 import { ProcessSync, Process } from './process.js';
 
@@ -978,9 +976,9 @@ export const chooseRowFromTable = (columns, rows, opt) => {
 
 const CONFIRM_DEFAULT_PROMPT = 'Are you sure?';
 
-/** 
+/**
  * @readonly
- * @enum {string} 
+ * @enum {string}
  */
 export const ConfirmAnswer = {
   YES: 'yes',
@@ -1493,7 +1491,6 @@ export const pager = (content, opt) => {
 
   addCustomArguments(cmdline, opt.custom?.args);
   const env = {
-    // @ts-ignore
     ...std.getenviron(),
     ...getEnv(opt.custom?.env),
   };
@@ -1503,7 +1500,6 @@ export const pager = (content, opt) => {
     return;
   }
 
-  // @ts-ignore
   os.exec(cmdline, {
     env,
   });
@@ -1513,7 +1509,6 @@ export const pager = (content, opt) => {
  * Clear the terminal :)
  */
 export const clear = () => {
-  // @ts-ignore
   os.exec(['clear']);
 };
 

--- a/src/os.js
+++ b/src/os.js
@@ -1,0 +1,659 @@
+/** @format */
+// @ts-check
+// @ts-ignore
+import * as os from 'os';
+
+/*
+  The os module provides Operating System specific functions:
+
+  - low level file access
+  - signals
+  - timers
+  - asynchronous I/O
+  - workers (threads)
+  
+  The OS functions usually return 0 if OK or an OS specific negative error code.
+ */
+
+/**
+ * Open a file
+ *
+ * @param {string} filename
+ * @param {number} flags
+ * @param {number} [mode=0o666] (default = 0o666)
+ *
+ * @returns {number} handle or < 0 if error.
+ */
+export const open =
+  /** @type {(filename: string, flags: number, mode?: number) => number} */ (
+    os.open
+  );
+
+/*
+  POSIX open flags
+ */
+
+/** @type {number} - open for reading only */
+export const O_RDONLY = os.O_RDONLY;
+
+/** @type {number} - open for writing only */
+export const O_WRONLY = os.O_WRONLY;
+
+/** @type {number} - open for reading and writing. The result is undefined if this flag is applied to a FIFO */
+export const O_RDWR = os.O_RDWR;
+
+/** @type {number} - if set, the file offset shall be set to the end of the file prior to each write */
+export const O_APPEND = os.O_APPEND;
+
+/**
+ * @type {number} - if the file exists, this flag has no effect except as noted under O_EXCL below.
+ *                  Otherwise, the file shall be created
+ */
+export const O_CREAT = os.O_CREAT;
+
+/** @type {number} - if O_CREAT and O_EXCL are set, open() shall fail if the file exists */
+export const O_EXCL = os.O_EXCL;
+
+/**
+ * @type {number} - if the file exists and is a regular file, and the file is successfully opened
+ *                  with O_RDWR or O_WRONLY, its length shall be truncated to 0
+ */
+export const O_TRUNC = os.O_TRUNC;
+
+/**
+ * Close a file
+ *
+ * @param {number} fd - file handle
+ *
+ * @returns {number} 0 if OK or -errno in case of I/O error
+ */
+export const close = /** @type {(fd: number) => number} */ (os.close);
+
+/**
+ * Seek in the file. Use std.SEEK_* for whence
+ *
+ * @param {number} fd - file handle
+ * @param {number} offset
+ * @param {number} whence
+ *
+ * @returns {number} 0 if OK or -errno in case of I/O error
+ */
+export const seek =
+  /** @type {(fd: number, offset: number, whence: number) => number} */ (
+    os.seek
+  );
+
+/**
+ * Read "length" bytes from the file handle "fd" to the ArrayBuffer "buffer" at byte position "offset"
+ *
+ * @param {number} fd
+ * @param {ArrayBuffer} buffer
+ * @param {number} offset
+ * @param {number} length
+ *
+ * @returns {number} the number of read bytes or < 0 if error
+ */
+export const read =
+  /** @type {(fd: number, buffer: ArrayBuffer, offset: number, length: number) => number} */ (
+    os.read
+  );
+
+/**
+ * Write "length" bytes to the file handle "fd" from the ArrayBuffer "buffer" at byte position "offset"
+ *
+ * @param {number} fd
+ * @param {number} buffer
+ * @param {number} offset
+ * @param {number} length
+ *
+ * @returns {number} the number of written bytes or < 0 if error
+ */
+export const write =
+  /** @type {(fd: number, buffer: ArrayBuffer, offset: number, length: number) => number} */ (
+    os.write
+  );
+
+/**
+ * Return true if "fd" is a TTY (terminal) handle
+ *
+ * @param {number} fd - file handle
+ *
+ * @returns {boolean}
+ */
+export const isatty = /** @type {(fd: number) => boolean} */ (os.isatty);
+
+/**
+ * Return the TTY size as [width, height] or null if not available
+ *
+ * @param {number} fd - file handle
+ *
+ * @returns {[number, number] | null}
+ */
+export const ttyGetWinSize =
+  /** @type {(fd: number) => [number, number] | null} */ (os.ttyGetWinSize);
+
+/**
+ * Set the TTY in raw mode
+ *
+ * @param {number} fd - file handle
+ */
+export const ttySetRaw = /** @type {(fd: number) => void} */ (os.ttySetRaw);
+
+/**
+ * Remove a file
+ *
+ * @param {string} filename
+ *
+ * @returns {number} 0 if OK or -errno
+ */
+export const remove = /** @type {(filename: string) => number} */ (os.remove);
+
+/**
+ * Rename a file
+ *
+ * @param {string} oldname
+ * @param {string} newname
+ *
+ * @returns {number} 0 if OK or -errno
+ */
+export const rename =
+  /** @type {(oldname: string, newname: string) => number} */ (os.rename);
+
+/**
+ * Return the canonicalized absolute pathname of a path
+ *
+ * @param {string} path
+ *
+ * @returns {[string, number]} [str, err] where "str" is the absolute pathname and "err" the error code
+ */
+export const realpath = /** @type {(path: string) => [string, number]} */ (
+  os.realpath
+);
+
+/**
+ * Return the current directory
+ *
+ * @returns {[string, number]} [str, err] where "str" is the current working directory and "err" the error code
+ */
+export const getcwd = /** @type {() => [string, number]} */ (os.getcwd);
+
+/**
+ * Change the current directory
+ *
+ * @param {string} path
+ *
+ * @returns {number} 0 if OK or -errno
+ */
+export const chdir = /** @type {(path: string) => number} */ (os.chdir);
+
+/**
+ * Create a directory at "path"
+ *
+ * @param {string} path
+ * @param {number} [mode=0o777] (default = 0o777)
+ *
+ * @returns {number} 0 if OK or -errno
+ */
+export const mkdir = /** @type {(path: string, mode?: number) => number} */ (
+  os.mkdir
+);
+
+/**
+ * @typedef {Object} FileStatus
+ * @property {number} dev - ID of device containing file
+ * @property {number} ino - file serial number
+ * @property {number} mode - mode of file
+ * @property {number} nlink - number of links to the file
+ * @property {number} uid - user ID of file
+ * @property {number} gid - group ID of file
+ * @property {number} rdev - device ID (if file is character or block special)
+ * @property {number} size - file size in bytes (if file is a regular file)
+ * @property {number} blocks - number of blocks allocated for this object
+ * @property {number} atime - time of last access (milliseconds since 1970)
+ * @property {number} mtime - time of last data modification (milliseconds since 1970)
+ * @property {number} ctime - time of last status change (milliseconds since 1970)
+ */
+
+/**
+ * Return informations about a file
+ *
+ * @param {string} path
+ *
+ * @returns {[FileStatus | null, number]} [obj, err] where "obj" containing the file status and "err" the error code
+ */
+export const stat =
+  /** @type {(path: string) => [FileStatus | null, number]} */ (os.stat);
+
+/**
+ * Return informations about a file.
+ * If path is a symbolink link, it returns information about the link itself,
+ * not the file that the link refers to.
+ *
+ * @param {string} path
+ *
+ * @returns {[FileStatus | null, number]} [obj, err] where "obj" containing the file status and "err" the error code
+ */
+export const lstat =
+  /** @type {(path: string) => [FileStatus | null, number]} */ (os.lstat);
+
+/*
+  Constants to interpret the mode property returned by stat().
+  They have the same value as in the C system header sys/stat.h
+
+  Ex: ((mode & os.S_IFMT) == os.S_IFCHR)
+ */
+
+/** @type {number} - bit mask used to extract the file type code from a mode value */
+export const S_IFMT = os.S_IFMT;
+
+/** @type {number} - file is a FIFO special file, or a pipe */
+export const S_IFIFO = os.S_IFIFO;
+
+/** @type {number} - file is a character special file (a device like a terminal) */
+export const S_IFCHR = os.S_IFCHR;
+
+/** @type {number} - file is a directory */
+export const S_IFDIR = os.S_IFDIR;
+
+/** @type {number} - file is a block special file (a device like a disk) */
+export const S_IFBLK = os.S_IFBLK;
+
+/** @type {number} - file is a regular file */
+export const S_IFREG = os.S_IFREG;
+
+/** @type {number} - file is a socket */
+export const S_IFSOCK = os.S_IFSOCK;
+
+/** @type {number} - file is a symbolic link */
+export const S_IFLNK = os.S_IFLNK;
+
+/** @type {number} - set group ID on execution */
+export const S_ISGID = os.S_ISGID;
+
+/** @type {number} - set user ID on execution */
+export const S_ISUID = os.S_ISUID;
+
+/**
+ * Change the access and modification times of a file
+ *
+ * @param {string} path
+ * @param {number} atime - access time (milliseconds since 1970)
+ * @param {number} mtime - modification time (millisecondes since 1970)
+ *
+ * @returns {number} 0 if OK or -errno
+ */
+export const utimes =
+  /** @type {(path: string, atime: number, mtime: number) => number} */ (
+    os.utimes
+  );
+
+/**
+ * Create a link at "linkpath" pointing to "target"
+ *
+ * @param {string} target
+ * @param {string} linkpath
+ *
+ * @returns {number} 0 if OK or -errno
+ */
+export const symlink =
+  /** @type {(target: string, linkpath: string) => number} */ (os.symlink);
+
+/**
+ * Return the target of a symlink
+ *
+ * @param {string} path
+ *
+ * @returns {[string, number]} [str, err] where "str" is the link target and "err" the error code
+ */
+export const readlink = /** @type {(path: string) => [string, number]} */ (
+  os.readlink
+);
+
+/**
+ * List entries in a directory
+ *
+ * @param {string} path
+ *
+ * @returns {[string[], number]} [array, err] where "array" is an array of strings containing the entries
+ *                               of the directory and "err" the error code
+ */
+export const readdir = /** @type {(path: string) => [string[], number]} */ (
+  os.readdir
+);
+
+/**
+ * Add a read handler to the file handle "fd".
+ * "func" is called each time there is data pending for "fd".
+ * A single read handler per file handle is supported.
+ * Use func = null to remove the handler.
+ *
+ * @param {number} fd
+ * @param {(() => void) | null} func
+ */
+export const setReadHandler =
+  /** @type {(fd: number, func: (() => void) | null) => void} */ (
+    os.setReadHandler
+  );
+
+/**
+ * Add a write handler to the file handle "fd".
+ * "func" is called each time data can be written to "fd".
+ * A single write handler per file handle is supported.
+ * Use func = null to remove the handler.
+ *
+ * @param {number} fd
+ * @param {(() => void) | null} func
+ */
+export const setWriteHandler =
+  /** @type {(fd: number, func: (() => void) | null) => void} */ (
+    os.setWriteHandler
+  );
+
+/**
+ * Call the function "func" when the signal "signal" happens.
+ * Only a single handler per signal number is supported.
+ * Use func = null to set the default handler.
+ * Use func = undefined to ignore the signal.
+ * Signal handlers can only be defined in the main thread.
+ *
+ * @param {number} signal
+ * @param {(() => void) | null} [func]
+ */
+export const signal =
+  /** @type {(signal: number, func?: (() => void) | null) => void} */ (
+    os.signal
+  );
+
+/*
+  POSIX signal numbers
+ */
+
+/** @type {number} - abort signal */
+export const SIGABRT = os.SIGABRT;
+
+/** @type {number} - alarm clock */
+export const SIGALRM = os.SIGALRM;
+
+/** @type {number} - child stopped or terminated */
+export const SIGCHLD = os.SIGCHLD;
+
+/** @type {number} - continue executing, if stopped */
+export const SIGCONT = os.SIGCONT;
+
+/** @type {number} - erroneous arithmetic operation */
+export const SIGFPE = os.SIGFPE;
+
+/** @type {number} - illegal instruction */
+export const SIGILL = os.SIGILL;
+
+/** @type {number} - interrupt from keyboard */
+export const SIGINT = os.SIGINT;
+
+/** @type {number} - write on a pipe with no one to read it */
+export const SIGPIPE = os.SIGPIPE;
+
+/** @type {number} - terminal quit signal */
+export const SIGQUIT = os.SIGQUIT;
+
+/** @type {number} - invalid memory reference */
+export const SIGSEGV = os.SIGSEGV;
+
+/** @type {number} - stop executing (cannot be caught or ignored). */
+export const SIGSTOP = os.SIGSTOP;
+
+/** @type {number} - termination signal */
+export const SIGTERM = os.SIGTERM;
+
+/** @type {number} - terminal stop signal */
+export const SIGTSTP = os.SIGTSTP;
+
+/** @type {number} - background process attempting read */
+export const SIGTTIN = os.SIGTTIN;
+
+/** @type {number} - background process attempting write */
+export const SIGTTOU = os.SIGTTOU;
+
+/** @type {number} - user-defined signal 1 */
+export const SIGUSR1 = os.SIGUSR1;
+
+/** @type {number} - user-defined signal 2 */
+export const SIGUSR2 = os.SIGUSR2;
+
+/**
+ * Send the signal "sig" to the process "pid"
+ *
+ * @param {number} pid
+ * @param {number} sig
+ */
+export const kill = /** @type {(pid: number, sig: number) => number} */ (
+  os.kill
+);
+
+/**
+ * @typedef {Object} ExecOptions
+ * @property {boolean} [block=true] - if true, wait until the process is terminated.
+ *                                    In this case, exec return the exit code if positive or the negated
+ *                                    signal number if the process was interrupted by a signal.
+ *                                    If false, do not block and return the process id of the child (default = true)
+ * @property {boolean} [usePath=true] - if true, the file is searched in the PATH environment variable (default = true)
+ * @property {string} [file] - set the file to be executed (default = args[0])
+ * @property {string} [cwd] - if present, set the working directory of the new process
+ * @property {number} [stdin] - if present, set the handle in the child for stdin
+ * @property {number} [stdout] - if present, set the handle in the child for stdout
+ * @property {number} [stderr] - if present, set the handle in the child for stderr
+ * @property {Record<string, string>} [env] - if present, set the process environment from the object key-value pairs.
+ *                                            Otherwise use the same environment as the current process
+ * @property {number} [uid] - if present, the process uid with setuid
+ * @property {number} [gid] - if present, the process gid with setgid
+ */
+
+/**
+ * Execute a process with the arguments "args"
+ *
+ * @param {string[]} args
+ * @param {ExecOptions} [options]
+ *
+ * @returns {number} exit code (blocking mode, success), signal number (blocking mode, error)
+ *                   or process ID of the child (non-blocking mode)
+ */
+export const exec =
+  /** @type {(args: string[], options?: ExecOptions) => number} */ (os.exec);
+
+/**
+ * Return the current process ID
+ *
+ * @returns {number}
+ */
+export const getpid = /** @type {() => number} */ (os.getpid);
+
+/**
+ * Execute waitpid Unix system call
+ *
+ * @param {number} pid
+ * @param {number} [options] - ex: WNOHANG
+ *
+ * @returns {[number, number]} [ret, status]. "ret" contains -errno in case of error
+ */
+export const waitpid =
+  /** @type {(pid: number, options?: number) => [number, number]} */ (
+    os.waitpid
+  );
+
+/*
+  Constants for the "options" argument of waitpid
+ */
+
+/** @type {number} - return immediately if no child has exited */
+export const WNOHANG = os.WNOHANG;
+
+/**
+ * Execute dup Unix system call.
+ * Allocates a new file descriptor that refers to the same open file as "fd"
+ *
+ * @param {number} fd
+ *
+ * @returns {number} new file descriptor number is guaranteed to be the lowest-numbered
+ *                   file descriptor that was unused in the calling process.
+ *                   In case of error, -errno is returned
+ */
+export const dup = /** @type {(fd: number) => number} */ (os.dup);
+
+/**
+ * Execute dup2 Unix system call.
+ * Adjust file descriptor "newfd" so that it now refers to the same open file as "oldfd"
+ *
+ * @param {number} oldfd
+ * @param {number} newfd
+ *
+ * @returns {number} new file descriptor number or -errno on error
+ */
+export const dup2 = /** @type {(oldfd: number, newfd: number) => number} */ (
+  os.dup2
+);
+
+/**
+ * Execute pipe Unix system call
+ *
+ * @returns {[number, number] | null} [read_fd, write_fd] or null in case of error
+ */
+export const pipe = /** @type {() => [number, number] | null} */ (os.pipe);
+
+/**
+ * Sleep during "delay_ms" milliseconds
+ *
+ * @param {number} delay_ms - delay in ms
+ */
+export const sleep = /** @type {(delay_ms: number) => void} */ (os.sleep);
+
+/**
+ * Asynchronouse sleep during "delay_ms" milliseconds.
+ *
+ * @param {number} delay_ms - delay in ms
+ *
+ * @return {Promise<void>}
+ */
+export const sleepAsync = /** @type {(delay_ms: number) => Promise<void>} */ (
+  os.sleepAsync
+);
+
+/**
+ * Return a timestamp in milliseconds with more precision than Date.now().
+ * The time origin is unspecified and is normally not impacted by system clock adjustments
+ *
+ * @returns {number}
+ */
+export const now = /** @type {() => number} */ (os.now);
+
+/**
+ * Call the function "func" after "delay" ms
+ *
+ * @param {() => void} func
+ * @param {number} delay - delay in ms
+ *
+ * @returns {Object} handle to the timer
+ */
+export const setTimeout =
+  /** @type {(func: () => void, delay: number) => Object} */ (os.setTimeout);
+
+/**
+ * Cancel a timer
+ *
+ * @param {Object} handle to the timer
+ */
+export const clearTimeout = /** @type {(handle: Object) => void} */ (
+  os.clearTimeout
+);
+
+/** @type {string} - string representing the platform */
+export const platform = os.platform;
+
+/**
+ * @typedef {Object} OnWorkerMessageEvent
+ * @property {any} data
+ */
+
+/**
+ * @typedef {Object} Worker
+ * @property {(msg: any) => void} postMessage
+ * @property {((event: OnWorkerMessageEvent) => void) | null} onmessage
+ */
+
+// @ts-ignore
+export { Worker } from 'os';
+
+/**
+ * Create a Worker
+ *
+ * @param {string} filename
+ *
+ * @returns {Worker}
+ */
+export const createWorker = (filename) => {
+  // @ts-ignore
+  return new os.Worker(filename);
+};
+
+/**
+ * Return the parent Worker instance
+ * It should be called from the child worker
+ *
+ * @returns {Worker | undefined}
+ */
+export const getParentWorker = () => {
+  // @ts-ignore
+  return os.Worker.parent;
+};
+
+/*
+  Extra functions only available with
+  https://github.com/ctn-malone/quickjs-cross-compiler?tab=readme-ov-file#extra-functions
+ */
+
+/**
+ * Apply or remove an advisory lock on an open file
+ *
+ * @param {number} fd
+ * @param {number} operation - os.LOCK_*
+ *
+ * @returns {number} 0 if OK or -errno in case of I/O error
+ */
+export const flock = /** @type {(fd: number, operation: number) => number} */ (
+  os.flock
+);
+
+/** @type {number} - place an exclusive lock. Only one process may hold an exclusive lock for a given file at a given time */
+export const LOCK_EX = os.LOCK_EX;
+
+/**
+ * @type {number} - a call to flock() may block if an incompatible lock is held by another process.
+ *                  To make a nonblocking request, include os.LOCK_NB with any of the above operations
+ */
+export const LOCK_NB = os.LOCK_NB;
+
+/**
+ * Generate a unique temporary filename from "template" (wrapper to the libc mkstemp).
+ *
+ * @param {string} template - template used to generate a unique temporary filename.
+ *                            It must end with XXXXXX
+ * @param {{filename: string}} outputObj - object where generated filename will be stored
+ *
+ * @returns {number} open file descriptor or -errno in case of error
+ */
+export const mkstemp =
+  /** @type {(template: string, outputObj: {filename: string}) => number} */ (
+    os.mkstemp
+  );
+
+/**
+ * Generate a unique temporary dirname from "template" (wrapper to the libc mkdtemp).
+ *
+ * @param {string} template - template used to generate a unique temporary dirname.
+ *                            It must end with XXXXXX
+ * @param {{errno: number}} [errorObj] - if defined, set its "errno" property to the error code or to 0 if no error occured
+ *
+ * @returns {string | null} temporary dirname or null on error
+ */
+export const mkdtemp =
+  /** @type {(template: string | null, errorObj?: {errno: number}) => string} */ (
+    os.mkdtemp
+  );

--- a/src/password-store.js
+++ b/src/password-store.js
@@ -11,8 +11,7 @@
 import { Process } from './process.js';
 import { getHomeDir } from './path.js';
 
-// @ts-ignore
-import * as os from 'os';
+import * as os from './os.js';
 
 const PASSWORD_STORE_DIRECTORY = '.password-store';
 
@@ -29,7 +28,6 @@ const checkPassword = (passwordPath) => {
     return false;
   }
   const p = `${home}/${PASSWORD_STORE_DIRECTORY}/${passwordPath}.gpg`;
-  // @ts-ignore
   const obj = os.stat(p);
   return obj[1] === 0;
 };

--- a/src/path.js
+++ b/src/path.js
@@ -2,10 +2,8 @@
 // @ts-check
 'use strict;';
 
-// @ts-ignore
-import * as std from 'std';
-// @ts-ignore
-import * as os from 'os';
+import * as std from './std.js';
+import * as os from './os.js';
 
 /**
  * @returns {string}
@@ -15,7 +13,6 @@ const getScriptDir = () => {
   const arr = scriptArgs[0].split('/');
   // only a single entry (ie: we're in the same directory) => return cwd
   if (1 === arr.length) {
-    // @ts-ignore
     return os.getcwd()[0];
   }
   // remove last entry
@@ -49,7 +46,7 @@ const getScriptName = (withoutExt) => {
  * @returns {string}
  */
 const getHomeDir = () => {
-  return std.getenv('HOME');
+  return /** @type {string} */ (std.getenv('HOME'));
 };
 
 export { getScriptDir, getScriptName, getHomeDir };

--- a/src/std.js
+++ b/src/std.js
@@ -1,0 +1,324 @@
+/** @format */
+// @ts-check
+// @ts-ignore
+import * as std from 'std';
+
+/*
+  The std module provides wrappers to the libc stdlib.h and stdio.h and a few other utilities
+ */
+
+/**
+ * Exit the process
+ *
+ * @param {number} exitCode
+ */
+export const exit = /** @type {(exitCode: number) => void}*/ (std.exit);
+
+/**
+ * @typedef {Object} EvalScriptOptions
+ * @property {boolean} [backtrace_barrier=false] - if true, error backtraces do not list the stack frames
+ *                                                 below the evalScript (default = false)
+ * @property {boolean} [async=false] - if true, await is accepted in the script and a promise is returned (default = false)
+ */
+
+/**
+ * Evaluate the string "str" as a script (global eval)
+ *
+ * @param {string} str
+ * @param {EvalScriptOptions} [options]
+ *
+ * @returns {any | Promise<any>}
+ */
+export const evalScript =
+  /** @type {(str: string, options?: EvalScriptOptions) => any | Promise<any>} */ (
+    std.evalScript
+  );
+
+/**
+ * Evaluate the file "filename" as a script (global eval)
+ *
+ * @param {string} filename
+ *
+ * @returns {any}
+ */
+export const loadScript = /** @type {(filename: string) => any} */ (
+  std.loadScript
+);
+
+/**
+ * Load the file "filename" and return it as a string assuming UTF-8 encoding
+ *
+ * @param {string} filename
+ *
+ * @returns {string | null} file content or null in case of I/O error
+ */
+export const loadFile = /** @type {(filename: string) => string | null} */ (
+  std.loadFile
+);
+
+/**
+ * @typedef {Object} StdFile
+ * @property {() => number} close - close the file. Return 0 if OK or -errno in case of I/O error
+ * @property {(str: string) => void} puts - outputs the string "str" with the UTF-8 encoding
+ * @property {(fmt: string, ...args: string[]) => number} printf - formatted printf. The same formats as the standard C library
+ *                                                                 printf are supported
+ * @property {() => void} flush - Flush the buffered file
+ * @property {(offset: number, whence: number) => number} seek - seek to a given file position ("whence" is std.SEEK_*).
+ *                                                               Return 0 if OK or -errno in case of I/O error
+ * @property {() => number} tell - return the current file position
+ * @property {() => number} tello - return the current file position as a bigint
+ * @property {() => boolean} eof - return true if end of file
+ * @property {() => number} fileno - return the associated OS handle
+ * @property {() => boolean} error - return true if there was an error
+ * @property {() => void} clearerr - clear the error indication
+ * @property {(buffer: ArrayBuffer, position: number,
+ *             length: number) => number} read - read "length" bytes from the file to the ArrayBuffer "buffer"
+ *                                               at byte position "position" (wrapper to the libc fread)
+ * @property {(buffer: ArrayBuffer, position: number,
+ *             length: number) => number} write - write "length" bytes to the file from the ArrayBuffer "buffer"
+ *                                                at byte position "position" (wrapper to the libc fwrite)
+ * @property {() => string | null} getline - return the next line from the file, assuming UTF-8 encoding, excluding the trailing line feed.
+ *                                           Return null if the end of file is reached
+ * @property {(max_size?: number) => string} readAsString - read "max_size" bytes from the file and return them as a string assuming UTF-8 encoding.
+ *                                                          If "max_size" is not present, the file is read entirely
+ * @property {() => number} getByte - return the next byte from the file. Return -1 if the end of file is reached
+ * @property {(c: number) => number} putByte - write one byte to the file
+ */
+
+/*
+  Constants for seek()
+ */
+
+/** @type {number} */
+export const SEEK_CUR = std.SEEK_CUR;
+
+/** @type {number} */
+export const SEEK_END = std.SEEK_END;
+
+/** @type {number} */
+export const SEEK_SET = std.SEEK_SET;
+
+/**
+ * Open a file (wrapper to the libc fopen())
+ *
+ * @param {string} filename
+ * @param {string} flags - ex: "r" for read, "w" for write ...
+ * @param {{errno: number}} [errorObj] - if defined, set its "errno" property to the error code or to 0 if no error occured
+ *
+ * @returns {StdFile | null} FILE object or null in case of I/O error
+ */
+export const open =
+  /** @type {(filename: string, flags: string, errorObj?: {errno: number}) => StdFile | null} */ (
+    std.open
+  );
+
+/**
+ * Open a process by creating a pipe (wrapper to the libc popen())
+ *
+ * @param {string} command
+ * @param {string} flags - ex: "r" for read, "w" for write ...
+ * @param {{errno: number}} [errorObj] - if defined, set its "errno" property to the error code or to 0 if no error occured
+ *
+ * @returns {StdFile | null} FILE object or null in case of I/O error
+ */
+export const popen =
+  /** @type {(command: string, flags: string, errorObj?: {errno: number}) => StdFile | null} */ (
+    std.popen
+  );
+
+/**
+ * Open a file from a file handle (wrapper to the libc fdopen())
+ *
+ * @param {number} fd
+ * @param {string} flags - ex: "r" for read, "w" for write ...
+ * @param {{errno: number}} [errorObj] - if defined, set its "errno" property to the error code or to 0 if no error occured
+ *
+ * @returns {StdFile | null} FILE object or null in case of I/O error
+ */
+export const fdopen =
+  /** @type {(fd: number, flags: string, errorObj?: {errno: number}) => StdFile | null} */ (
+    std.fdopen
+  );
+
+/**
+ * Open a temporary file
+ *
+ * @param {number} fd
+ * @param {string} flags - ex: "r" for read, "w" for write ...
+ * @param {{errno: number}} [errorObj] - if defined, set its "errno" property to the error code or to 0 if no error occured
+ *
+ * @returns {StdFile | null} FILE object or null in case of I/O error
+ */
+export const tmpfile =
+  /** @type {(errorObj?: {errno: number}) => StdFile | null} */ (std.tmpfile);
+
+/**
+ * Outputs the string "str" with the UTF-8 encoding.
+ * Equivalent to std.out.puts(str)
+ *
+ * @param {string} str
+ */
+export const puts = /** @type {(str: string) => void} */ (std.puts);
+
+/**
+ * Formatted printf.
+ * The same formats as the standard C library printf are supported.
+ * Equivalent to std.out.printf(fmt, ...args)
+ *
+ * @param {string} fmt
+ * @param {...string} args
+ *
+ * @returns {number}
+ */
+export const printf =
+  /** @type {(fmt: string, ...args: string[]) => number} */ (std.printf);
+
+/**
+ * Equivalent to the libc sprintf()
+ *
+ * @param {string} fmt
+ * @param {...string} args
+ *
+ * @returns {string}
+ */
+export const sprintf =
+  /** @type {(fmt: string, ...args: string[]) => string} */ (std.sprintf);
+
+/**
+ * Wrappers to the libc file stdin
+ */
+const _in = /** @type {StdFile} */ (std.in);
+/**
+ * Wrappers to the libc file stdout
+ */
+const _out = /** @type {StdFile} */ (std.out);
+/**
+ * Wrappers to the libc file stderr
+ */
+const _err = /** @type {StdFile} */ (std.err);
+export { _in as in, _out as out, _err as err };
+
+/**
+ * Enumeration object containing the integer value of common errors
+ *
+ * @readonly
+ * @enum {number}
+ */
+export const Error = {
+  EACCES: std.Error.EACCES,
+  EBADF: std.Error.EBADF,
+  EBUSY: std.Error.EBUSY,
+  EEXIST: std.Error.EEXIST,
+  EINTR: std.Error.EINTR,
+  EINVAL: std.Error.EINVAL,
+  EIO: std.Error.EIO,
+  ENOENT: std.Error.ENOENT,
+  ENOLCK: std.Error.ENOLCK,
+  ENOSPC: std.Error.ENOSPC,
+  ENOSYS: std.Error.ENOSYS,
+  EPERM: std.Error.EPERM,
+  EPIPE: std.Error.EPIPE,
+  EWOULDBLOCK: std.Error.EWOULDBLOCK,
+};
+
+/**
+ * Return a string that describes the error "errno"
+ *
+ * @param {number} errno
+ *
+ * @returns {string}
+ */
+export const strerror = /** @type {(errno: number) => string} */ (std.strerror);
+
+/**
+ * Manually invoke the cycle removal algorithm.
+ * The cycle removal algorithm is automatically started when needed,
+ * so this function is useful in case of specific memory constraints
+ * or for testing
+ */
+export const gc = /** @type {() => void} */ (std.gc);
+
+/**
+ * Return the value of the environment variable "name" or undefined if it is not defined
+ *
+ * @param {string} name
+ *
+ * @returns {string | undefined}
+ */
+export const getenv = /** @type {(name: string) => string | undefined} */ (
+  std.getenv
+);
+
+/**
+ * Set the value of the environment variable "name" to the string "value"
+ *
+ * @param {string} name
+ * @param {string} value
+ */
+export const setenv = /** @type {(name: string, value: string) => void} */ (
+  std.setenv
+);
+
+/**
+ * Delete the environment variable "name"
+ *
+ * @param {string} name
+ */
+export const unsetenv = /** @type {(name: string) => void} */ (std.unsetenv);
+
+/**
+ * Return an object containing the environment variables as key-value pairs
+ *
+ * @returns {Record<string, string>}
+ */
+export const getenviron = /** @type {() => Record<string, string>} */ (
+  std.getenviron
+);
+
+/**
+ * @typedef {Object} UrlGetOptions
+ * @property {boolean} [binary=false] - if true, the response is an ArrayBuffer instead of a string. When a string is returned,
+ *                                      the data is assumed to be UTF-8 encoded (default = false)
+ * @property {boolean} [full=false] - if true, the response is a UrlGetResponse object. Response is null is case of protocol or network error.
+ *                                    If false, the response is a string (response content), if the status is between 200 and 299, null otherwise.
+ */
+
+/**
+ * @typedef {Object} UrlGetResponse
+ * @property {string | ArrayBuffer | null} response - response content
+ * @property {string} responseHeaders - headers separated by CRLF
+ * @property {number} status - status code
+ */
+
+/**
+ * Return the value of the environment variable "name" or undefined if it is not defined
+ *
+ * @param {string} url
+ * @param {UrlGetOptions} [options]
+ *
+ * @returns {string | ArrayBuffer | UrlGetResponse | null}
+ */
+export const urlGet =
+  /** @type {(url: string, options?: UrlGetOptions) => string | ArrayBuffer | UrlGetResponse | null} */ (
+    std.urlGet
+  );
+
+/**
+ * Parse "str" using a superset of JSON.parse.
+ * The following extensions are accepted:
+ *
+ * - single line and multiline comments
+ * - unquoted properties (ASCII-only Javascript identifiers)
+ * - trailing comma in array and object definitions
+ * - single quoted strings
+ * - \f and \v are accepted as space characters
+ * - leading plus in numbers
+ * - octal (0o prefix) and hexadecimal (0x prefix) numbers
+ *
+ * @param {string} str
+ *
+ * @returns {any}
+ */
+export const parseExtJSON = /** @type {(str: string) => any} */ (
+  std.parseExtJSON
+);

--- a/src/strings.js
+++ b/src/strings.js
@@ -2,12 +2,10 @@
 // @ts-check
 'use strict;';
 
-// @ts-ignore
-import * as std from 'std';
-// @ts-ignore
-import * as os from 'os';
+import * as std from './std.js';
 
 import { Process, ensureProcessResult, exec } from './process.js';
+
 /*
   String helpers. Mostly for internal use
  */
@@ -277,15 +275,15 @@ const base64EncodeStr = async (plainStr) => {
  * @return {Promise<string>}
  */
 const base64EncodeBytesArray = async (bytesArray) => {
-  const outputFile = std.tmpfile();
-  const inputFile = std.tmpfile();
+  const outputFile = /** @type {std.StdFile} */ (std.tmpfile());
+  const inputFile = /** @type {std.StdFile} */ (std.tmpfile());
   inputFile.write(bytesArray.buffer, 0, bytesArray.length);
   inputFile.flush();
 
   const process = new Process(['base64', '-w', '0'], {
     stdin: inputFile.fileno(),
     stdout: outputFile.fileno(),
-  })
+  });
   await process.run();
   inputFile.close();
   if (!process.success) {
@@ -322,7 +320,7 @@ const base64DecodeStr = async (base64Str) => {
  * @return {Promise<Uint8Array>}
  */
 const base64DecodeBytesArray = async (base64Str) => {
-  const outputFile = std.tmpfile();
+  const outputFile = /** @type {std.StdFile} */ (std.tmpfile());
 
   const process = new Process(['base64', '-d', '-'], {
     input: base64Str,

--- a/src/timers.js
+++ b/src/timers.js
@@ -6,8 +6,7 @@
   setInterval / clearInterval implementation
  */
 
-// @ts-ignore
-import * as os from 'os';
+import * as os from './os.js';
 
 const timers = new Map();
 
@@ -20,7 +19,6 @@ const timers = new Map();
  */
 const wait = (delay) => {
   return new Promise((resolve) => {
-    // @ts-ignore
     os.setTimeout(() => {
       return resolve();
     }, delay);
@@ -40,7 +38,6 @@ const setInterval = (cb, interval) => {
   const state = { enabled: true };
   timers.set(timer, state);
   const fn = () => {
-    // @ts-ignore
     os.setTimeout(() => {
       if (!state.enabled) {
         return;

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,17 @@
+/**
+ * JSDoc types lack a non-null assertion.
+ * https://github.com/Microsoft/TypeScript/issues/23405#issuecomment-873331031
+ *
+ * @template T
+ * @param {T} value
+ * 
+ * @returns {NonNullable<T>}
+ */
+export const notNull = (value) => {
+    // Use `==` to check for both null and undefined
+    if (value == null) {
+      throw new Error(`Did not expect value to be null or undefined`);
+    }
+    return value;
+  };
+  

--- a/src/version.js
+++ b/src/version.js
@@ -10,7 +10,7 @@
   An exception will be thrown in case a non semver version is passed as argument
  */
 
-const VERSION = '0.11.0';
+const VERSION = '0.12.0';
 
 /**
  * Check whether or not a version is in semver format

--- a/test/run.js
+++ b/test/run.js
@@ -1,4 +1,5 @@
 /** @format */
+// @ts-check
 
 import arg from '../src/arg.js';
 import * as path from '../src/path.js';
@@ -13,7 +14,7 @@ import testSsh from './tests/test.ssh.js';
 import testGum from './tests/test.gum.js';
 import testArg from './tests/test.arg.js';
 
-import * as std from 'std';
+import * as std from '../src/std.js';
 
 const testSuites = [
   'timers',
@@ -64,6 +65,7 @@ try {
             ','
           )}])`
         );
+        // @ts-ignore
         err.code = 'ARG_INVALID_OPTION';
         throw err;
       }
@@ -78,6 +80,7 @@ try {
             ','
           )}])`
         );
+        // @ts-ignore
         err.code = 'ARG_INVALID_OPTION';
         throw err;
       }

--- a/test/tests/test.arg.js
+++ b/test/tests/test.arg.js
@@ -1,10 +1,9 @@
 /** @format */
 // @ts-check
 
-// @ts-ignore
-import * as std from 'std';
-// @ts-ignore
-import * as os from 'os';
+import * as std from '../../src/std.js';
+import * as os from '../../src/os.js';
+import { notNull } from '../../src/types.js';
 
 import { tester } from '../../src/tester.js';
 import { execSync } from '../../src/process.js';
@@ -484,7 +483,7 @@ export default () => {
   tester.test('arg - path validator (read)', () => {
     let tmpDir = createTmpDir();
     let validator = arg.path().read();
-    let file = std.open(`${tmpDir}/file`, 'w+');
+    let file = notNull(std.open(`${tmpDir}/file`, 'w+'));
     file.puts('abcdef');
     file.close();
     try {
@@ -514,7 +513,7 @@ export default () => {
 
     tmpDir = createTmpDir();
     validator = arg.path().read({ json: true });
-    file = std.open(`${tmpDir}/file`, 'w+');
+    file = notNull(std.open(`${tmpDir}/file`, 'w+'));
     file.puts('{"key":"value"}');
     file.close();
     try {
@@ -531,7 +530,7 @@ export default () => {
     tmpDir = createTmpDir();
     exceptionThrown = false;
     validator = arg.path().read({ json: true });
-    file = std.open(`${tmpDir}/file`, 'w+');
+    file = notNull(std.open(`${tmpDir}/file`, 'w+'));
     file.puts('abcdef');
     file.close();
     try {
@@ -1207,7 +1206,7 @@ export default () => {
       }
     );
     const help = args.getHelp();
-    const expectedHelp = std.loadFile('data/help1.txt').trim();
+    const expectedHelp = notNull(std.loadFile('data/help1.txt')).trim();
     tester.assertEq(help, expectedHelp, `help should be as expected`);
   });
 };

--- a/test/tests/test.curl.js
+++ b/test/tests/test.curl.js
@@ -1,6 +1,9 @@
 /** @format */
+// @ts-check
 
-import * as std from 'std';
+import * as std from '../../src/std.js';
+import { notNull } from '../../src/types.js';
+
 import { tester } from '../../src/tester.js';
 import { Curl, curlRequest, multiCurl } from '../../src/curl.js';
 
@@ -161,6 +164,7 @@ export default () => {
     );
 
     c = new Curl('http://127.0.0.1', {
+      // @ts-ignore
       connectTimeout: 'notANumber',
     });
     expectedCmdline = `curl -D /dev/stderr -q -X GET -L --url http://127.0.0.1`;
@@ -183,6 +187,7 @@ export default () => {
     );
 
     c = new Curl('http://127.0.0.1', {
+      // @ts-ignore
       maxTime: 'notANumber',
     });
     expectedCmdline = `curl -D /dev/stderr -q -X GET -L --url http://127.0.0.1`;
@@ -385,7 +390,7 @@ export default () => {
 
     c = new Curl('http://127.0.0.1', {
       method: 'post',
-      body: {},
+      body: '{}',
     });
     expectedCmdline = `curl -D /dev/stderr -q -X POST -L --url http://127.0.0.1`;
     cmdline = c.cmdline;
@@ -506,7 +511,10 @@ export default () => {
       tester.assertEq(c.body, undefined, 'Payload should be undefined');
       tester.assert(c.curlFailed, '{curlFailed} should be {true}');
       tester.assertNeq(c.curlError, undefined, '{curlError} should be defined');
-      tester.assert(0 != c.curlError.length, '{curlError} should not be empty');
+      tester.assert(
+        0 != notNull(c.curlError).length,
+        '{curlError} should not be empty'
+      );
 
       done();
     },
@@ -634,7 +642,7 @@ export default () => {
     'curl.Curl (POST request from file)',
     async (done) => {
       const jsonFile = 'data/post_json1.json';
-      const reqBody = JSON.parse(std.loadFile(jsonFile));
+      const reqBody = JSON.parse(notNull(std.loadFile(jsonFile)));
       let c = new Curl('http://jsonplaceholder.typicode.com/posts', {
         method: 'post',
         jsonFile: jsonFile,
@@ -930,7 +938,9 @@ export default () => {
       },
     ];
     for (const e of setCookieValues) {
-      const cookies = c._parseSetCookieHeaders(e.cookiesStrings);
+      const cookies = /** @type {any} */ (c)._parseSetCookieHeaders(
+        e.cookiesStrings
+      );
       tester.assertEq(
         cookies,
         e.expectedCookies,

--- a/test/tests/test.curl.js
+++ b/test/tests/test.curl.js
@@ -390,7 +390,8 @@ export default () => {
 
     c = new Curl('http://127.0.0.1', {
       method: 'post',
-      body: '{}',
+      // @ts-ignore
+      body: {},
     });
     expectedCmdline = `curl -D /dev/stderr -q -X POST -L --url http://127.0.0.1`;
     cmdline = c.cmdline;

--- a/test/tests/test.gum.js
+++ b/test/tests/test.gum.js
@@ -1,9 +1,6 @@
 /** @format */
 // @ts-check
 
-// @ts-ignore
-import * as std from 'std';
-
 import { tester } from '../../src/tester.js';
 import * as gum from '../../src/gum.js';
 

--- a/test/tests/test.path.js
+++ b/test/tests/test.path.js
@@ -1,13 +1,21 @@
+/** @format */
+// @ts-check
+
 import { tester } from '../../src/tester.js';
-import { getScriptName } from '../../src/path.js'
+import { getScriptName } from '../../src/path.js';
 
 export default () => {
-
-    tester.test('path.getScriptName', () => {
-        let name;
-        name = getScriptName(false);
-        tester.assert(name == 'run.js', `script name with extension should be 'run.js' (${name})`);
-        name = getScriptName(true);
-        tester.assert(name == 'run', `script name without extension should be 'run' (${name})`);
-    });
-}
+  tester.test('path.getScriptName', () => {
+    let name;
+    name = getScriptName(false);
+    tester.assert(
+      name == 'run.js',
+      `script name with extension should be 'run.js' (${name})`
+    );
+    name = getScriptName(true);
+    tester.assert(
+      name == 'run',
+      `script name without extension should be 'run' (${name})`
+    );
+  });
+};

--- a/test/tests/test.process.js
+++ b/test/tests/test.process.js
@@ -1,7 +1,10 @@
 /** @format */
+// @ts-check
 
-import * as os from 'os';
-import * as std from 'std';
+import * as std from '../../src/std.js';
+import * as os from '../../src/os.js';
+import { notNull } from '../../src/types.js';
+
 import { tester } from '../../src/tester.js';
 import {
   Process,
@@ -419,7 +422,7 @@ export default () => {
   tester.test(
     'process.Process (custom stdout)',
     async (done) => {
-      const tmpFile = std.tmpfile();
+      const tmpFile = notNull(std.tmpfile());
       // redirect stderr will be ignored
       const opt = {
         trim: false,
@@ -833,12 +836,12 @@ export default () => {
 
       // load input
       const inputFile = 'data/input1.txt';
-      const input = std.loadFile(inputFile).trim();
-      const tmpFile = std.tmpfile();
+      const input = notNull(std.loadFile(inputFile)).trim();
+      const tmpFile = notNull(std.tmpfile());
       tmpFile.puts(input);
       tmpFile.flush();
       // rewind
-      tmpFile.seek(0);
+      tmpFile.seek(0, std.SEEK_SET);
 
       const expectedContent = input
         .split('\n')
@@ -872,7 +875,7 @@ export default () => {
 
       // load input
       const inputFile = 'data/input1.txt';
-      const input = std.loadFile(inputFile).trim();
+      const input = notNull(std.loadFile(inputFile)).trim();
 
       const expectedContent = input
         .split('\n')
@@ -1298,12 +1301,12 @@ export default () => {
 
     // load input
     const inputFile = 'data/input1.txt';
-    const input = std.loadFile(inputFile).trim();
-    const tmpFile = std.tmpfile();
+    const input = notNull(std.loadFile(inputFile)).trim();
+    const tmpFile = notNull(std.tmpfile());
     tmpFile.puts(input);
     tmpFile.flush();
     // rewind
-    tmpFile.seek(0);
+    tmpFile.seek(0, std.SEEK_SET);
 
     const expectedContent = input
       .split('\n')
@@ -1330,7 +1333,7 @@ export default () => {
 
     // load input
     const inputFile = 'data/input1.txt';
-    const input = std.loadFile(inputFile).trim();
+    const input = notNull(std.loadFile(inputFile)).trim();
 
     const expectedContent = input
       .split('\n')

--- a/test/tests/test.ssh.js
+++ b/test/tests/test.ssh.js
@@ -1,621 +1,831 @@
+/** @format */
+// @ts-check
+
 import { tester } from '../../src/tester.js';
-import { Ssh, sshExec, multiSsh } from '../../src/ssh.js'
+import { Ssh, sshExec, multiSsh } from '../../src/ssh.js';
 import { wait } from '../../src/timers.js';
 
-import * as std from 'std';
-import * as os from 'os';
+import * as std from '../../src/std.js';
+import * as os from '../../src/os.js';
+import { notNull } from '../../src/types.js';
 
 export default () => {
+  // wether or not we should do real ssh connections
+  const real_ssh_connect =
+    '1' == std.getenv('QJS_EXT_LIB_TEST_SSH_REAL_CONNECT');
+  // whether or not local forward should be tested
+  const real_local_forward =
+    real_ssh_connect &&
+    '1' == std.getenv('QJS_EXT_LIB_TEST_SSH_REAL_LOCAL_FORWARD');
+  // whether or not remote forward should be tested
+  const real_remote_forward =
+    real_ssh_connect &&
+    '1' == std.getenv('QJS_EXT_LIB_TEST_SSH_REAL_REMOTE_FORWARD');
+  // full path to data directory
+  const data_directory = `${os.getcwd()[0]}/data`;
 
-    // wether or not we should do real ssh connections
-    const real_ssh_connect = ('1' == std.getenv('QJS_EXT_LIB_TEST_SSH_REAL_CONNECT'));
-    // whether or not local forward should be tested
-    const real_local_forward = (real_ssh_connect && ('1' == std.getenv('QJS_EXT_LIB_TEST_SSH_REAL_LOCAL_FORWARD')));
-    // whether or not remote forward should be tested
-    const real_remote_forward = (real_ssh_connect && ('1' == std.getenv('QJS_EXT_LIB_TEST_SSH_REAL_REMOTE_FORWARD')));
-    // full path to data directory
-    const data_directory = `${os.getcwd()[0]}/data`;
+  /**
+   * Get cmdline for a script located in data directory
+   *
+   * @param {string} cmd command line to execute
+   * @return {string}
+   */
+  const getRemoteCmd = (cmd) => {
+    return `${data_directory}/${cmd}`;
+  };
 
-    /**
-     * Get cmdline for a script located in data directory
-     * 
-     * @param {string} cmd command line to execute 
-     * @return {string}
-     */
-    const getRemoteCmd = (cmd) => {
-        return `${data_directory}/${cmd}`;
-    }
+  tester.test('ssh.Ssh (mock / default)', () => {
+    const ssh = new Ssh('127.0.0.1', 'date');
+    const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -o StrictHostKeyChecking=no 127.0.0.1 date`;
+    const cmdline = ssh.cmdline;
+    tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
+    tester.assertEq(ssh.port, 22, `port should match`);
+    tester.assertEq(ssh.host, '127.0.0.1', `host should match`);
+    tester.assertEq(ssh.user, undefined, `user should match`);
+    tester.assertEq(ssh.uri, '127.0.0.1:22', `uri should match`);
+  });
 
-    tester.test('ssh.Ssh (mock / default)', () => {
-        const ssh = new Ssh('127.0.0.1', 'date');
-        const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -o StrictHostKeyChecking=no 127.0.0.1 date`;
-        const cmdline = ssh.cmdline;
-        tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
-        tester.assertEq(ssh.port, 22, `port should match`);
-        tester.assertEq(ssh.host, '127.0.0.1', `host should match`);
-        tester.assertEq(ssh.user, undefined, `user should match`);
-        tester.assertEq(ssh.uri, '127.0.0.1:22', `uri should match`);
+  tester.test('ssh.Ssh (mock / no cmd)', () => {
+    const ssh = new Ssh('127.0.0.1', '');
+    const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -N -o StrictHostKeyChecking=no 127.0.0.1`;
+    const cmdline = ssh.cmdline;
+    tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
+    tester.assertEq(ssh.port, 22, `port should match`);
+    tester.assertEq(ssh.host, '127.0.0.1', `host should match`);
+    tester.assertEq(ssh.user, undefined, `user should match`);
+    tester.assertEq(ssh.uri, '127.0.0.1:22', `uri should match`);
+  });
+
+  tester.test('ssh.Ssh (mock / custom port using options)', () => {
+    const ssh = new Ssh('127.0.0.1', 'date', { port: 2222 });
+    const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 2222 -F /dev/null -o StrictHostKeyChecking=no 127.0.0.1 date`;
+    const cmdline = ssh.cmdline;
+    tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
+    tester.assertEq(ssh.port, 2222, `port should match`);
+    tester.assertEq(ssh.host, '127.0.0.1', `host should match`);
+    tester.assertEq(ssh.user, undefined, `user should match`);
+    tester.assertEq(ssh.uri, '127.0.0.1:2222', `uri should match`);
+  });
+
+  tester.test('ssh.Ssh (mock / custom port using host uri)', () => {
+    const ssh = new Ssh('127.0.0.1:2222', 'date');
+    const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 2222 -F /dev/null -o StrictHostKeyChecking=no 127.0.0.1 date`;
+    const cmdline = ssh.cmdline;
+    tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
+    tester.assertEq(ssh.port, 2222, `port should match`);
+    tester.assertEq(ssh.host, '127.0.0.1', `host should match`);
+    tester.assertEq(ssh.user, undefined, `user should match`);
+    tester.assertEq(ssh.uri, '127.0.0.1:2222', `uri should match`);
+  });
+
+  tester.test('ssh.Ssh (mock / custom user using options)', () => {
+    const ssh = new Ssh('127.0.0.1', 'date', { user: 'admin' });
+    const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -o StrictHostKeyChecking=no admin@127.0.0.1 date`;
+    const cmdline = ssh.cmdline;
+    tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
+    tester.assertEq(ssh.port, 22, `port should match`);
+    tester.assertEq(ssh.host, '127.0.0.1', `host should match`);
+    tester.assertEq(ssh.user, 'admin', `user should match`);
+    tester.assertEq(ssh.uri, 'admin@127.0.0.1:22', `uri should match`);
+  });
+
+  tester.test('ssh.Ssh (mock / custom user using host uri)', () => {
+    const ssh = new Ssh('admin@127.0.0.1', 'date');
+    const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -o StrictHostKeyChecking=no admin@127.0.0.1 date`;
+    const cmdline = ssh.cmdline;
+    tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
+    tester.assertEq(ssh.port, 22, `port should match`);
+    tester.assertEq(ssh.host, '127.0.0.1', `host should match`);
+    tester.assertEq(ssh.user, 'admin', `user should match`);
+    tester.assertEq(ssh.uri, 'admin@127.0.0.1:22', `uri should match`);
+  });
+
+  tester.test('ssh.Ssh (mock / custom user & port using host uri)', () => {
+    const ssh = new Ssh('admin@127.0.0.1:2222', 'date');
+    const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 2222 -F /dev/null -o StrictHostKeyChecking=no admin@127.0.0.1 date`;
+    const cmdline = ssh.cmdline;
+    tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
+    tester.assertEq(ssh.port, 2222, `port should match`);
+    tester.assertEq(ssh.host, '127.0.0.1', `host should match`);
+    tester.assertEq(ssh.user, 'admin', `user should match`);
+    tester.assertEq(ssh.uri, 'admin@127.0.0.1:2222', `uri should match`);
+  });
+
+  tester.test('ssh.Ssh (mock / {ignoreUserConfig:false} )', () => {
+    const ssh = new Ssh('127.0.0.1', 'date', { ignoreUserConfig: false });
+    const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -o StrictHostKeyChecking=no 127.0.0.1 date`;
+    const cmdline = ssh.cmdline;
+    tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
+  });
+
+  tester.test('ssh.Ssh (mock / {checkHostKey:true} )', () => {
+    const ssh = new Ssh('127.0.0.1', 'date', { checkHostKey: true });
+    const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null 127.0.0.1 date`;
+    const cmdline = ssh.cmdline;
+    tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
+  });
+
+  tester.test('ssh.Ssh (mock / {connectTimeout:5} )', () => {
+    const ssh = new Ssh('127.0.0.1', 'date', { connectTimeout: 5 });
+    const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=5 127.0.0.1 date`;
+    const cmdline = ssh.cmdline;
+    tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
+  });
+
+  tester.test('ssh.Ssh (mock / {pseudoTerminal:true} )', () => {
+    const ssh = new Ssh('127.0.0.1', 'date', { pseudoTerminal: true });
+    const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -t -o StrictHostKeyChecking=no 127.0.0.1 date`;
+    const cmdline = ssh.cmdline;
+    tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
+  });
+
+  tester.test('ssh.Ssh (mock / identityFile)', () => {
+    const ssh = new Ssh('127.0.0.1', 'date', {
+      identityFile: '/home/user/.ssh/id_rsa',
     });
+    const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -o StrictHostKeyChecking=no -o IdentityFile=/home/user/.ssh/id_rsa -o IdentitiesOnly=yes 127.0.0.1 date`;
+    const cmdline = ssh.cmdline;
+    tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
+  });
 
-    tester.test('ssh.Ssh (mock / no cmd)', () => {
-        const ssh = new Ssh('127.0.0.1', '');
-        const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -N -o StrictHostKeyChecking=no 127.0.0.1`;
-        const cmdline = ssh.cmdline;
-        tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
-        tester.assertEq(ssh.port, 22, `port should match`);
-        tester.assertEq(ssh.host, '127.0.0.1', `host should match`);
-        tester.assertEq(ssh.user, undefined, `user should match`);
-        tester.assertEq(ssh.uri, '127.0.0.1:22', `uri should match`);
+  tester.test('ssh.Ssh (mock / environment variables)', () => {
+    const ssh = new Ssh('127.0.0.1', 'date', {
+      env: { var1: 1, var2: 2 },
     });
+    const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -o StrictHostKeyChecking=no 127.0.0.1 export var1=1 var2=2 ; date`;
+    const cmdline = ssh.cmdline;
+    tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
+  });
 
-    tester.test('ssh.Ssh (mock / custom port using options)', () => {
-        const ssh = new Ssh('127.0.0.1', 'date', {port:2222});
-        const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 2222 -F /dev/null -o StrictHostKeyChecking=no 127.0.0.1 date`;
-        const cmdline = ssh.cmdline;
-        tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
-        tester.assertEq(ssh.port, 2222, `port should match`);
-        tester.assertEq(ssh.host, '127.0.0.1', `host should match`);
-        tester.assertEq(ssh.user, undefined, `user should match`);
-        tester.assertEq(ssh.uri, '127.0.0.1:2222', `uri should match`);
+  tester.test('ssh.Ssh (mock / supported custom SSH opts)', () => {
+    const ssh = new Ssh('127.0.0.1', 'date', {
+      sshOpt: { Ciphers: 'aes128-ctr,aes192-ctr' },
     });
+    const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -o StrictHostKeyChecking=no -o Ciphers=aes128-ctr,aes192-ctr 127.0.0.1 date`;
+    const cmdline = ssh.cmdline;
+    tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
+  });
 
-    tester.test('ssh.Ssh (mock / custom port using host uri)', () => {
-        const ssh = new Ssh('127.0.0.1:2222', 'date');
-        const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 2222 -F /dev/null -o StrictHostKeyChecking=no 127.0.0.1 date`;
-        const cmdline = ssh.cmdline;
-        tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
-        tester.assertEq(ssh.port, 2222, `port should match`);
-        tester.assertEq(ssh.host, '127.0.0.1', `host should match`);
-        tester.assertEq(ssh.user, undefined, `user should match`);
-        tester.assertEq(ssh.uri, '127.0.0.1:2222', `uri should match`);
+  tester.test('ssh.Ssh (mock / unsupported custom SSH opts)', () => {
+    const ssh = new Ssh('127.0.0.1', 'date', {
+      sshOpt: { LogLevel: 'DEBUG3' },
     });
+    const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -o StrictHostKeyChecking=no 127.0.0.1 date`;
+    const cmdline = ssh.cmdline;
+    tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
+  });
 
-    tester.test('ssh.Ssh (mock / custom user using options)', () => {
-        const ssh = new Ssh('127.0.0.1', 'date', {user:'admin'});
-        const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -o StrictHostKeyChecking=no admin@127.0.0.1 date`;
-        const cmdline = ssh.cmdline;
-        tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
-        tester.assertEq(ssh.port, 22, `port should match`);
-        tester.assertEq(ssh.host, '127.0.0.1', `host should match`);
-        tester.assertEq(ssh.user, 'admin', `user should match`);
-        tester.assertEq(ssh.uri, 'admin@127.0.0.1:22', `uri should match`);
+  tester.test('ssh.Ssh (mock / {redirectStderr:true} )', () => {
+    const ssh = new Ssh('127.0.0.1', 'date', { redirectStderr: true });
+    const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -o StrictHostKeyChecking=no 127.0.0.1 date 2>&1`;
+    const cmdline = ssh.cmdline;
+    tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
+  });
+
+  tester.test('ssh.Ssh (mock / local forward)', () => {
+    const ssh = new Ssh('127.0.0.1', '', {
+      localForward: [
+        { remoteAddr: '127.0.0.1', localPort: 10001, remotePort: 22 },
+        { remoteAddr: '127.0.0.1', localPort: 10002, remotePort: 22 },
+      ],
     });
+    const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -N -o StrictHostKeyChecking=no -o LocalForward=127.0.0.1:10001 127.0.0.1:22 -o LocalForward=127.0.0.1:10002 127.0.0.1:22 127.0.0.1`;
+    const cmdline = ssh.cmdline;
+    tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
+  });
 
-    tester.test('ssh.Ssh (mock / custom user using host uri)', () => {
-        const ssh = new Ssh('admin@127.0.0.1', 'date');
-        const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -o StrictHostKeyChecking=no admin@127.0.0.1 date`;
-        const cmdline = ssh.cmdline;
-        tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
-        tester.assertEq(ssh.port, 22, `port should match`);
-        tester.assertEq(ssh.host, '127.0.0.1', `host should match`);
-        tester.assertEq(ssh.user, 'admin', `user should match`);
-        tester.assertEq(ssh.uri, 'admin@127.0.0.1:22', `uri should match`);
+  tester.test('ssh.Ssh (mock / remote forward)', () => {
+    const ssh = new Ssh('127.0.0.1', '', {
+      remoteForward: [
+        { remoteAddr: '127.0.0.1', localPort: 22, remotePort: 10001 },
+        { remoteAddr: '127.0.0.1', localPort: 22, remotePort: 10002 },
+      ],
     });
+    const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -N -o StrictHostKeyChecking=no -o RemoteForward=127.0.0.1:10001 127.0.0.1:22 -o RemoteForward=127.0.0.1:10002 127.0.0.1:22 127.0.0.1`;
+    const cmdline = ssh.cmdline;
+    tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
+  });
 
-    tester.test('ssh.Ssh (mock / custom user & port using host uri)', () => {
-        const ssh = new Ssh('admin@127.0.0.1:2222', 'date');
-        const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 2222 -F /dev/null -o StrictHostKeyChecking=no admin@127.0.0.1 date`;
-        const cmdline = ssh.cmdline;
-        tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
-        tester.assertEq(ssh.port, 2222, `port should match`);
-        tester.assertEq(ssh.host, '127.0.0.1', `host should match`);
-        tester.assertEq(ssh.user, 'admin', `user should match`);
-        tester.assertEq(ssh.uri, 'admin@127.0.0.1:2222', `uri should match`);
-    });
+  tester.test(
+    'ssh.Ssh (real / execute test1.sh {redirectStderr:false} )',
+    async (done) => {
+      const cmd = getRemoteCmd('test1.sh 5');
+      const ssh = new Ssh('127.0.0.1', cmd);
+      const result = await ssh.run();
+      tester.assert(result, `execution should succeed`);
+      tester.assert(!ssh.failed, `failed should be false`);
+      tester.assert(!ssh.sshFailed, `sshFailed should be false`);
+      tester.assertEq(ssh.sshError, undefined, `sshError should be undefined`);
+      tester.assertEq(
+        ssh.sshErrorReason,
+        undefined,
+        `sshErrorReason should be undefined`
+      );
+      tester.assert(!ssh.commandFailed, `commandFailed should be false`);
+      tester.assert(!ssh.didTimeout, `didTimeout should be false`);
+      tester.assert(!ssh.wasCancelled, `wasCancelled should be false`);
+      const stdout = ssh.stdout;
+      const expectedStdout = `2\n4`;
+      tester.assertEq(stdout, expectedStdout, `stdout content should match`);
+      const stderr = ssh.stderr;
+      const expectedStderr = `1\n3\n5`;
+      tester.assertEq(stderr, expectedStderr, `stderr content should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (mock / {ignoreUserConfig:false} )', () => {
-        const ssh = new Ssh('127.0.0.1', 'date', {ignoreUserConfig:false});
-        const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -o StrictHostKeyChecking=no 127.0.0.1 date`;
-        const cmdline = ssh.cmdline;
-        tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
-    });
+  tester.test(
+    'ssh.Ssh (real / execute test1.sh {redirectStderr:true} )',
+    async (done) => {
+      const cmd = getRemoteCmd('test1.sh 5');
+      const ssh = new Ssh('127.0.0.1', cmd, { redirectStderr: true });
+      const result = await ssh.run();
+      tester.assert(result, `execution should succeed`);
+      tester.assert(!ssh.failed, `failed should be false`);
+      tester.assert(!ssh.sshFailed, `sshFailed should be false`);
+      tester.assertEq(ssh.sshError, undefined, `sshError should be undefined`);
+      tester.assertEq(
+        ssh.sshErrorReason,
+        undefined,
+        `sshErrorReason should be undefined`
+      );
+      tester.assert(!ssh.commandFailed, `commandFailed should be false`);
+      tester.assert(!ssh.didTimeout, `didTimeout should be false`);
+      tester.assert(!ssh.wasCancelled, `wasCancelled should be false`);
+      const stdout = ssh.stdout;
+      const expectedStdout = `1\n2\n3\n4\n5`;
+      tester.assertEq(stdout, expectedStdout, `stdout content should match`);
+      const stderr = ssh.stderr;
+      const expectedStderr = '';
+      tester.assertEq(stderr, expectedStderr, `stderr content should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (mock / {checkHostKey:true} )', () => {
-        const ssh = new Ssh('127.0.0.1', 'date', {checkHostKey:true});
-        const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null 127.0.0.1 date`;
-        const cmdline = ssh.cmdline;
-        tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
-    });
+  tester.test(
+    'ssh.Ssh (real / execute test1.sh with non-zero exit code)',
+    async (done) => {
+      const cmd = getRemoteCmd('test1.sh 5 3');
+      const ssh = new Ssh('127.0.0.1', cmd);
+      const result = await ssh.run();
+      tester.assert(!result, `execution should fail`);
+      tester.assert(ssh.failed, `failed should be true`);
+      tester.assert(!ssh.sshFailed, `sshFailed should be false`);
+      tester.assertEq(ssh.sshError, undefined, `sshError should be undefined`);
+      tester.assertEq(
+        ssh.sshErrorReason,
+        undefined,
+        `sshErrorReason should be undefined`
+      );
+      tester.assert(ssh.commandFailed, `commandFailed should be true`);
+      tester.assert(!ssh.didTimeout, `didTimeout should be false`);
+      tester.assert(!ssh.wasCancelled, `wasCancelled should be false`);
+      const state = ssh.state;
+      tester.assertEq(state.exitCode, 3, `exitCode should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (mock / {connectTimeout:5} )', () => {
-        const ssh = new Ssh('127.0.0.1', 'date', {connectTimeout:5});
-        const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=5 127.0.0.1 date`;
-        const cmdline = ssh.cmdline;
-        tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
-    });
+  tester.test(
+    'ssh.Ssh (real / invalid command)',
+    async (done) => {
+      const cmd = getRemoteCmd('invalid.sh');
+      const ssh = new Ssh('127.0.0.1', cmd);
+      const result = await ssh.run();
+      tester.assert(!result, `execution should fail`);
+      tester.assert(ssh.failed, `failed should be true`);
+      tester.assert(!ssh.sshFailed, `sshFailed should be false`);
+      tester.assertEq(ssh.sshError, undefined, `sshError should be undefined`);
+      tester.assertEq(
+        ssh.sshErrorReason,
+        undefined,
+        `sshErrorReason should be undefined`
+      );
+      tester.assert(ssh.commandFailed, `commandFailed should be true`);
+      tester.assert(!ssh.didTimeout, `didTimeout should be false`);
+      tester.assert(!ssh.wasCancelled, `wasCancelled should be false`);
+      const state = ssh.state;
+      tester.assertEq(state.exitCode, 127, `exitCode should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (mock / {pseudoTerminal:true} )', () => {
-        const ssh = new Ssh('127.0.0.1', 'date', {pseudoTerminal:true});
-        const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -t -o StrictHostKeyChecking=no 127.0.0.1 date`;
-        const cmdline = ssh.cmdline;
-        tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
-    });
+  tester.test(
+    'ssh.Ssh (real / invalid auth)',
+    async (done) => {
+      const ssh = new Ssh('127.0.0.1', 'date', {
+        identityFile: '/dev/null',
+      });
+      const result = await ssh.run();
+      tester.assert(!result, `execution should fail`);
+      tester.assert(ssh.failed, `failed should be true`);
+      tester.assert(ssh.sshFailed, `sshFailed should be true`);
+      tester.assertNeq(ssh.sshError, undefined, `sshError should be defined`);
+      tester.assertEq(
+        ssh.sshErrorReason,
+        'auth_error',
+        `sshErrorReason should match`
+      );
+      tester.assert(!ssh.commandFailed, `commandFailed should be false`);
+      tester.assert(!ssh.didTimeout, `didTimeout should be false`);
+      tester.assert(!ssh.wasCancelled, `wasCancelled should be false`);
+      const state = ssh.state;
+      tester.assertEq(state.exitCode, 255, `exitCode should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (mock / identityFile)', () => {
-        const ssh = new Ssh('127.0.0.1', 'date', {identityFile:'/home/user/.ssh/id_rsa'});
-        const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -o StrictHostKeyChecking=no -o IdentityFile=/home/user/.ssh/id_rsa -o IdentitiesOnly=yes 127.0.0.1 date`;
-        const cmdline = ssh.cmdline;
-        tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
-    });
+  tester.test(
+    'ssh.Ssh (real / execute test2.sh {trim:false} )',
+    async (done) => {
+      const cmd = getRemoteCmd('test2.sh 5');
+      const ssh = new Ssh('127.0.0.1', cmd, { trim: false });
+      const result = await ssh.run();
+      tester.assert(result, `execution should succeed`);
+      const stdout = ssh.stdout;
+      const expectedStdout = `24\n`;
+      tester.assertEq(stdout, expectedStdout, `stdout content should match`);
+      const stderr = ssh.stderr;
+      const expectedStderr = `135\n`;
+      tester.assertEq(stderr, expectedStderr, `stderr content should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (mock / environment variables)', () => {
-        const ssh = new Ssh('127.0.0.1', 'date', {
-            env:{'var1':1,'var2':2}
-        });
-        const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -o StrictHostKeyChecking=no 127.0.0.1 export var1=1 var2=2 ; date`;
-        const cmdline = ssh.cmdline;
-        tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
-    });
+  tester.test(
+    'ssh.Ssh (real / execute test4.sh {trim:false,skipBlankLines:false} )',
+    async (done) => {
+      const cmd = getRemoteCmd('test4.sh 5');
+      const ssh = new Ssh('127.0.0.1', cmd, {
+        trim: false,
+        skipBlankLines: false,
+      });
+      const result = await ssh.run();
+      tester.assert(result, `execution should succeed`);
+      const stdout = ssh.stdout;
+      const expectedStdout = `2\n\n4\n\n`;
+      tester.assertEq(stdout, expectedStdout, `stdout content should match`);
+      const stderr = ssh.stderr;
+      const expectedStderr = `1\n\n3\n\n5\n\n`;
+      tester.assertEq(stderr, expectedStderr, `stderr content should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (mock / supported custom SSH opts)', () => {
-        const ssh = new Ssh('127.0.0.1', 'date', {sshOpt:{'Ciphers':'aes128-ctr,aes192-ctr'}});
-        const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -o StrictHostKeyChecking=no -o Ciphers=aes128-ctr,aes192-ctr 127.0.0.1 date`;
-        const cmdline = ssh.cmdline;
-        tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
-    });
+  tester.test(
+    'ssh.Ssh (real / execute test4.sh {trim:true,skipBlankLines:false} )',
+    async (done) => {
+      const cmd = getRemoteCmd('test4.sh 5');
+      const ssh = new Ssh('127.0.0.1', cmd, {
+        trim: true,
+        skipBlankLines: false,
+      });
+      const result = await ssh.run();
+      tester.assert(result, `execution should succeed`);
+      const stdout = ssh.stdout;
+      const expectedStdout = `2\n\n4`;
+      tester.assertEq(stdout, expectedStdout, `stdout content should match`);
+      const stderr = ssh.stderr;
+      const expectedStderr = `1\n\n3\n\n5`;
+      tester.assertEq(stderr, expectedStderr, `stderr content should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (mock / unsupported custom SSH opts)', () => {
-        const ssh = new Ssh('127.0.0.1', 'date', {sshOpt:{'LogLevel':'DEBUG3'}});
-        const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -o StrictHostKeyChecking=no 127.0.0.1 date`;
-        const cmdline = ssh.cmdline;
-        tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
-    });
+  tester.test(
+    'ssh.Ssh (real / execute test3.sh {trim:false,skipBlankLines:true} )',
+    async (done) => {
+      const cmd = getRemoteCmd('test4.sh 5');
+      const ssh = new Ssh('127.0.0.1', cmd, {
+        trim: false,
+        skipBlankLines: true,
+      });
+      const result = await ssh.run();
+      tester.assert(result, `execution should succeed`);
+      const stdout = ssh.stdout;
+      const expectedStdout = `2\n4\n`;
+      tester.assertEq(stdout, expectedStdout, `stdout content should match`);
+      const stderr = ssh.stderr;
+      const expectedStderr = `1\n3\n5\n`;
+      tester.assertEq(stderr, expectedStderr, `stderr content should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (mock / {redirectStderr:true} )', () => {
-        const ssh = new Ssh('127.0.0.1', 'date', {redirectStderr:true});
-        const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -o StrictHostKeyChecking=no 127.0.0.1 date 2>&1`;
-        const cmdline = ssh.cmdline;
-        tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
-    });
+  tester.test(
+    'ssh.Ssh (real / execute test3.sh {trim:true,skipBlankLines:true} )',
+    async (done) => {
+      const cmd = getRemoteCmd('test4.sh 5');
+      const ssh = new Ssh('127.0.0.1', cmd, {
+        trim: true,
+        skipBlankLines: true,
+      });
+      const result = await ssh.run();
+      tester.assert(result, `execution should succeed`);
+      const stdout = ssh.stdout;
+      const expectedStdout = `2\n4`;
+      tester.assertEq(stdout, expectedStdout, `stdout content should match`);
+      const stderr = ssh.stderr;
+      const expectedStderr = `1\n3\n5`;
+      tester.assertEq(stderr, expectedStderr, `stderr content should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (mock / local forward)', () => {
-        const ssh = new Ssh('127.0.0.1', '', {localForward:[
-            {remoteAddr:'127.0.0.1', localPort:10001, remotePort:22},
-            {remoteAddr:'127.0.0.1', localPort:10002, remotePort:22},
-        ]});
-        const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -N -o StrictHostKeyChecking=no -o LocalForward=127.0.0.1:10001 127.0.0.1:22 -o LocalForward=127.0.0.1:10002 127.0.0.1:22 127.0.0.1`;
-        const cmdline = ssh.cmdline;
-        tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
-    });
+  tester.test(
+    'ssh.Ssh (real / execute test7.sh {maxTime:1} )',
+    async (done) => {
+      const cmd = getRemoteCmd('test7.sh 5');
+      const ssh = new Ssh('127.0.0.1', cmd, { maxTime: 1 });
+      const result = await ssh.run();
+      tester.assert(!result, `execution should fail`);
+      tester.assert(ssh.failed, `failed should be true`);
+      tester.assert(!ssh.sshFailed, `sshFailed should be false`);
+      tester.assertEq(ssh.sshError, undefined, `sshError should be undefined`);
+      tester.assertEq(
+        ssh.sshErrorReason,
+        undefined,
+        `sshErrorReason should be undefined`
+      );
+      tester.assert(ssh.commandFailed, `commandFailed should be true`);
+      tester.assert(ssh.didTimeout, `didTimeout should be true`);
+      tester.assert(!ssh.wasCancelled, `wasCancelled should be false`);
+      const state = ssh.state;
+      tester.assertEq(state.exitCode, -os.SIGTERM, `exitCode should match`);
+      tester.assertEq(state.signal, 'SIGTERM', `signal should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (mock / remote forward)', () => {
-        const ssh = new Ssh('127.0.0.1', '', {remoteForward:[
-            {remoteAddr:'127.0.0.1', localPort:22, remotePort:10001},
-            {remoteAddr:'127.0.0.1', localPort:22, remotePort:10002},
-        ]});
-        const expectedCmdline = `ssh -v -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -p 22 -F /dev/null -N -o StrictHostKeyChecking=no -o RemoteForward=127.0.0.1:10001 127.0.0.1:22 -o RemoteForward=127.0.0.1:10002 127.0.0.1:22 127.0.0.1`;
-        const cmdline = ssh.cmdline;
-        tester.assertEq(cmdline, expectedCmdline, `cmdline should match`);
-    });
+  tester.test(
+    'ssh.Ssh (real / execute test7.sh and cancel)',
+    async (done) => {
+      const cmd = getRemoteCmd('test7.sh 5');
+      const ssh = new Ssh('127.0.0.1', cmd);
+      const p = ssh.run();
+      await wait(500);
+      ssh.cancel();
+      const result = await p;
+      tester.assert(!result, `execution should fail`);
+      tester.assert(ssh.failed, `failed should be true`);
+      tester.assert(!ssh.sshFailed, `sshFailed should be false`);
+      tester.assertEq(ssh.sshError, undefined, `sshError should be undefined`);
+      tester.assertEq(
+        ssh.sshErrorReason,
+        undefined,
+        `sshErrorReason should be undefined`
+      );
+      tester.assert(ssh.commandFailed, `commandFailed should be true`);
+      tester.assert(!ssh.didTimeout, `didTimeout should be false`);
+      tester.assert(ssh.wasCancelled, `wasCancelled should be true`);
+      const state = ssh.state;
+      tester.assertEq(state.exitCode, -os.SIGINT, `exitCode should match`);
+      tester.assertEq(state.signal, 'SIGINT', `signal should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (real / execute test1.sh {redirectStderr:false} )', async (done) => {
-        const cmd = getRemoteCmd('test1.sh 5');
-        const ssh = new Ssh('127.0.0.1', cmd);
-        const result = await ssh.run();
-        tester.assert(result, `execution should succeed`);
-        tester.assert(!ssh.failed, `failed should be false`);
-        tester.assert(!ssh.sshFailed, `sshFailed should be false`);
-        tester.assertEq(ssh.sshError, undefined, `sshError should be undefined`);
-        tester.assertEq(ssh.sshErrorReason, undefined, `sshErrorReason should be undefined`);
-        tester.assert(!ssh.commandFailed, `commandFailed should be false`);
-        tester.assert(!ssh.didTimeout, `didTimeout should be false`);
-        tester.assert(!ssh.wasCancelled, `wasCancelled should be false`);
-        const stdout = ssh.stdout;
-        const expectedStdout = `2\n4`;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match`);
-        const stderr = ssh.stderr;
-        const expectedStderr = `1\n3\n5`;
-        tester.assertEq(stderr, expectedStderr, `stderr content should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
+  tester.test(
+    'ssh.Ssh (real / execute test2.sh with event listeners {lineBuffered:false} )',
+    async (done) => {
+      const cmd = getRemoteCmd('test2.sh 5');
+      const ssh = new Ssh('127.0.0.1', cmd, { lineBuffered: false });
+      let stdout = '',
+        stderr = '';
+      ssh.setEventListener('stdout', (obj) => {
+        stdout += obj.data;
+      });
+      ssh.setEventListener('stderr', (obj) => {
+        stderr += obj.data;
+      });
+      const result = await ssh.run();
+      tester.assert(result, `execution should succeed`);
+      const expectedStdout = `24\n`;
+      tester.assertEq(stdout, expectedStdout, `stdout content should match`);
+      const expectedStderr = `135\n`;
+      tester.assertEq(stderr, expectedStderr, `stderr content should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (real / execute test1.sh {redirectStderr:true} )', async (done) => {
-        const cmd = getRemoteCmd('test1.sh 5');
-        const ssh = new Ssh('127.0.0.1', cmd, {redirectStderr:true});
-        const result = await ssh.run();
-        tester.assert(result, `execution should succeed`);
-        tester.assert(!ssh.failed, `failed should be false`);
-        tester.assert(!ssh.sshFailed, `sshFailed should be false`);
-        tester.assertEq(ssh.sshError, undefined, `sshError should be undefined`);
-        tester.assertEq(ssh.sshErrorReason, undefined, `sshErrorReason should be undefined`);
-        tester.assert(!ssh.commandFailed, `commandFailed should be false`);
-        tester.assert(!ssh.didTimeout, `didTimeout should be false`);
-        tester.assert(!ssh.wasCancelled, `wasCancelled should be false`);
-        const stdout = ssh.stdout;
-        const expectedStdout = `1\n2\n3\n4\n5`;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match`);
-        const stderr = ssh.stderr;
-        const expectedStderr = '';
-        tester.assertEq(stderr, expectedStderr, `stderr content should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
+  tester.test(
+    'ssh.Ssh (real / execute test2.sh with event listeners {lineBuffered:true} )',
+    async (done) => {
+      const cmd = getRemoteCmd('test2.sh 5');
+      const ssh = new Ssh('127.0.0.1', cmd, { lineBuffered: true });
+      let stdout = '',
+        stderr = '';
+      ssh.setEventListener('stdout', (obj) => {
+        stdout += obj.data;
+      });
+      ssh.setEventListener('stderr', (obj) => {
+        stderr += obj.data;
+      });
+      const result = await ssh.run();
+      tester.assert(result, `execution should succeed`);
+      const expectedStdout = `24`;
+      tester.assertEq(stdout, expectedStdout, `stdout content should match`);
+      const expectedStderr = `135`;
+      tester.assertEq(stderr, expectedStderr, `stderr content should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (real / execute test1.sh with non-zero exit code)', async (done) => {
-        const cmd = getRemoteCmd('test1.sh 5 3');
-        const ssh = new Ssh('127.0.0.1', cmd);
-        const result = await ssh.run();
-        tester.assert(!result, `execution should fail`);
-        tester.assert(ssh.failed, `failed should be true`);
-        tester.assert(!ssh.sshFailed, `sshFailed should be false`);
-        tester.assertEq(ssh.sshError, undefined, `sshError should be undefined`);
-        tester.assertEq(ssh.sshErrorReason, undefined, `sshErrorReason should be undefined`);
-        tester.assert(ssh.commandFailed, `commandFailed should be true`);
-        tester.assert(!ssh.didTimeout, `didTimeout should be false`);
-        tester.assert(!ssh.wasCancelled, `wasCancelled should be false`);
-        const state = ssh.state;
-        tester.assertEq(state.exitCode, 3, `exitCode should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
+  tester.test(
+    'ssh.Ssh (real / execute test1.sh {pseudoTerminal:true,normalizeEol:false} )',
+    async (done) => {
+      const cmd = getRemoteCmd('test1.sh 5');
+      const ssh = new Ssh('127.0.0.1', cmd, { pseudoTerminal: true });
+      const result = await ssh.run();
+      tester.assert(result, `execution should succeed`);
+      const stdout = ssh.stdout;
+      const expectedStdout = `1\r\n2\r\n3\r\n4\r\n5`;
+      tester.assertEq(stdout, expectedStdout, `stdout content should match`);
+      const stderr = ssh.stderr;
+      // when using pseudo terminal, stderr will be redirected to stdout by OpenSSH
+      const expectedStderr = '';
+      tester.assertEq(stderr, expectedStderr, `stderr content should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (real / invalid command)', async (done) => {
-        const cmd = getRemoteCmd('invalid.sh');
-        const ssh = new Ssh('127.0.0.1', cmd);
-        const result = await ssh.run();
-        tester.assert(!result, `execution should fail`);
-        tester.assert(ssh.failed, `failed should be true`);
-        tester.assert(!ssh.sshFailed, `sshFailed should be false`);
-        tester.assertEq(ssh.sshError, undefined, `sshError should be undefined`);
-        tester.assertEq(ssh.sshErrorReason, undefined, `sshErrorReason should be undefined`);
-        tester.assert(ssh.commandFailed, `commandFailed should be true`);
-        tester.assert(!ssh.didTimeout, `didTimeout should be false`);
-        tester.assert(!ssh.wasCancelled, `wasCancelled should be false`);
-        const state = ssh.state;
-        tester.assertEq(state.exitCode, 127, `exitCode should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
+  tester.test(
+    'ssh.Ssh (real / execute test1.sh {pseudoTerminal:true,normalizeEol:true} )',
+    async (done) => {
+      const cmd = getRemoteCmd('test1.sh 5');
+      const ssh = new Ssh('127.0.0.1', cmd, {
+        pseudoTerminal: true,
+        normalizeEol: true,
+      });
+      const result = await ssh.run();
+      tester.assert(result, `execution should succeed`);
+      const stdout = ssh.stdout;
+      const expectedStdout = `1\n2\n3\n4\n5`;
+      tester.assertEq(stdout, expectedStdout, `stdout content should match`);
+      const stderr = ssh.stderr;
+      // when using pseudo terminal, stderr will be redirected to stdout by OpenSSH
+      const expectedStderr = '';
+      tester.assertEq(stderr, expectedStderr, `stderr content should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (real / invalid auth)', async (done) => {
-        const ssh = new Ssh('127.0.0.1', 'date', {
-            identityFile:'/dev/null'
-        });
-        const result = await ssh.run();
-        tester.assert(!result, `execution should fail`);
-        tester.assert(ssh.failed, `failed should be true`);
-        tester.assert(ssh.sshFailed, `sshFailed should be true`);
-        tester.assertNeq(ssh.sshError, undefined, `sshError should be defined`);
-        tester.assertEq(ssh.sshErrorReason, 'auth_error', `sshErrorReason should match`);
-        tester.assert(!ssh.commandFailed, `commandFailed should be false`);
-        tester.assert(!ssh.didTimeout, `didTimeout should be false`);
-        tester.assert(!ssh.wasCancelled, `wasCancelled should be false`);
-        const state = ssh.state;
-        tester.assertEq(state.exitCode, 255, `exitCode should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
+  tester.test(
+    'ssh.Ssh (real / execute test5.sh without environment variables)',
+    async (done) => {
+      const cmd = getRemoteCmd('test5.sh');
+      const ssh = new Ssh('127.0.0.1', cmd);
+      const result = await ssh.run();
+      tester.assert(result, `execution should succeed`);
+      const stdout = ssh.stdout;
+      const expectedStdout = `DUMMY_VAR1=\nDUMMY_VAR2=`;
+      tester.assertEq(stdout, expectedStdout, `stdout content should match`);
+      const stderr = ssh.stderr;
+      const expectedStderr = '';
+      tester.assertEq(stderr, expectedStderr, `stderr content should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (real / execute test2.sh {trim:false} )', async (done) => {
-        const cmd = getRemoteCmd('test2.sh 5');
-        const ssh = new Ssh('127.0.0.1', cmd, {trim:false});
-        const result = await ssh.run();
-        tester.assert(result, `execution should succeed`);
-        const stdout = ssh.stdout;
-        const expectedStdout = `24\n`;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match`);
-        const stderr = ssh.stderr;
-        const expectedStderr = `135\n`;
-        tester.assertEq(stderr, expectedStderr, `stderr content should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
+  tester.test(
+    'ssh.Ssh (real / execute test5.sh with environment variables)',
+    async (done) => {
+      const cmd = getRemoteCmd('test5.sh');
+      const ssh = new Ssh('127.0.0.1', cmd, {
+        env: { DUMMY_VAR1: 1, DUMMY_VAR2: 2 },
+      });
+      const result = await ssh.run();
+      tester.assert(result, `execution should succeed`);
+      const stdout = ssh.stdout;
+      const expectedStdout = `DUMMY_VAR1=1\nDUMMY_VAR2=2`;
+      tester.assertEq(stdout, expectedStdout, `stdout content should match`);
+      const stderr = ssh.stderr;
+      const expectedStderr = '';
+      tester.assertEq(stderr, expectedStderr, `stderr content should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (real / execute test4.sh {trim:false,skipBlankLines:false} )', async (done) => {
-        const cmd = getRemoteCmd('test4.sh 5');
-        const ssh = new Ssh('127.0.0.1', cmd, {trim:false,skipBlankLines:false});
-        const result = await ssh.run();
-        tester.assert(result, `execution should succeed`);
-        const stdout = ssh.stdout;
-        const expectedStdout = `2\n\n4\n\n`;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match`);
-        const stderr = ssh.stderr;
-        const expectedStderr = `1\n\n3\n\n5\n\n`;
-        tester.assertEq(stderr, expectedStderr, `stderr content should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
+  tester.test(
+    'ssh.Ssh (real / local port forwarding  [local:10001 => remote:22, local:10002 => remote:22])',
+    async (done) => {
+      const ssh = new Ssh('127.0.0.1', '', {
+        localForward: [
+          { remoteAddr: '127.0.0.1', remotePort: 22, localPort: 10001 },
+          { remoteAddr: '127.0.0.1', remotePort: 22, localPort: 10002 },
+        ],
+      });
+      let result, stdout;
+      const p = ssh.run();
+      result = await ssh.waitForSessionSetup();
+      tester.assert(result, `session setup should succeed`);
+      const cmd = getRemoteCmd('test7.sh');
+      const expectedStdout = 'OK';
+      const ssh1 = new Ssh('127.0.0.1', cmd, { port: 10001 });
+      result = await ssh1.run();
+      tester.assert(result, `execution using local port 10001 should succeed`);
+      stdout = ssh1.stdout;
+      tester.assertEq(
+        stdout,
+        expectedStdout,
+        `stdout content should match when using local port 10001`
+      );
+      const ssh2 = new Ssh('127.0.0.1', cmd, { port: 10002 });
+      result = await ssh2.run();
+      tester.assert(result, `execution using local port 10002 should succeed`);
+      stdout = ssh2.stdout;
+      tester.assertEq(
+        stdout,
+        expectedStdout,
+        `stdout content should match when using local port 10002`
+      );
+      // stop forwarding
+      ssh.cancel();
+      await p;
+      tester.assert(ssh.wasCancelled, `wasCancelled should be true`);
+      done();
+    },
+    { isAsync: true, skip: !real_local_forward }
+  );
 
-    tester.test('ssh.Ssh (real / execute test4.sh {trim:true,skipBlankLines:false} )', async (done) => {
-        const cmd = getRemoteCmd('test4.sh 5');
-        const ssh = new Ssh('127.0.0.1', cmd, {trim:true,skipBlankLines:false});
-        const result = await ssh.run();
-        tester.assert(result, `execution should succeed`);
-        const stdout = ssh.stdout;
-        const expectedStdout = `2\n\n4`;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match`);
-        const stderr = ssh.stderr;
-        const expectedStderr = `1\n\n3\n\n5`;
-        tester.assertEq(stderr, expectedStderr, `stderr content should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
+  tester.test(
+    'ssh.Ssh (real / remote port forwarding  [remote:10001 => local:22, remote:10002 => local:22])',
+    async (done) => {
+      const ssh = new Ssh('127.0.0.1', '', {
+        remoteForward: [
+          { remoteAddr: '127.0.0.1', remotePort: 10001, localPort: 22 },
+          { remoteAddr: '127.0.0.1', remotePort: 10002, localPort: 22 },
+        ],
+      });
+      let result, stdout;
+      const p = ssh.run();
+      result = await ssh.waitForSessionSetup();
+      tester.assert(result, `session setup should succeed`);
+      tester.assertEq(
+        ssh.remotePorts,
+        undefined,
+        `remotePorts should be undefined`
+      );
+      const cmd = getRemoteCmd('test7.sh');
+      const expectedStdout = 'OK';
+      const ssh1 = new Ssh('127.0.0.1', cmd, { port: 10001 });
+      result = await ssh1.run();
+      tester.assert(result, `execution using remote port 10001 should succeed`);
+      stdout = ssh1.stdout;
+      tester.assertEq(
+        stdout,
+        expectedStdout,
+        `stdout content should match when using remote port 10001`
+      );
+      const ssh2 = new Ssh('127.0.0.1', cmd, { port: 10002 });
+      result = await ssh2.run();
+      tester.assert(result, `execution using port 10002 should succeed`);
+      stdout = ssh2.stdout;
+      tester.assertEq(
+        stdout,
+        expectedStdout,
+        `stdout content should match when using remote port 10002`
+      );
+      // stop forwarding
+      ssh.cancel();
+      await p;
+      tester.assert(ssh.wasCancelled, `wasCancelled should be true`);
+      done();
+    },
+    { isAsync: true, skip: !real_remote_forward }
+  );
 
-    tester.test('ssh.Ssh (real / execute test3.sh {trim:false,skipBlankLines:true} )', async (done) => {
-        const cmd = getRemoteCmd('test4.sh 5');
-        const ssh = new Ssh('127.0.0.1', cmd, {trim:false,skipBlankLines:true});
-        const result = await ssh.run();
-        tester.assert(result, `execution should succeed`);
-        const stdout = ssh.stdout;
-        const expectedStdout = `2\n4\n`;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match`);
-        const stderr = ssh.stderr;
-        const expectedStderr = `1\n3\n5\n`;
-        tester.assertEq(stderr, expectedStderr, `stderr content should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
+  tester.test(
+    'ssh.Ssh (real / remote port forwarding  [remote:? => local:22])',
+    async (done) => {
+      const ssh = new Ssh('127.0.0.1', '', {
+        remoteForward: [{ remoteAddr: '127.0.0.1', localPort: 22 }],
+      });
+      let result, stdout;
+      const p = ssh.run();
+      result = await ssh.waitForSessionSetup();
+      tester.assert(result, `session setup should succeed`);
+      const remotePorts = ssh.remotePorts;
+      tester.assertNeq(
+        remotePorts,
+        undefined,
+        `remotePorts should not be undefined`
+      );
+      tester.assertEq(
+        notNull(remotePorts).length,
+        1,
+        `size of remotePorts should be as expected`
+      );
+      let dynamicPort = 0;
+      if (undefined !== remotePorts) {
+        dynamicPort = remotePorts[0].remotePort;
+      }
+      const cmd = getRemoteCmd('test7.sh');
+      const expectedStdout = 'OK';
+      const ssh1 = new Ssh('127.0.0.1', cmd, { port: dynamicPort });
+      result = await ssh1.run();
+      tester.assert(
+        result,
+        `execution using dynamically allocated remote port ${dynamicPort} should succeed`
+      );
+      stdout = ssh1.stdout;
+      tester.assertEq(
+        stdout,
+        expectedStdout,
+        `stdout content should match when using dynamically allocated remote port`
+      );
+      // stop forwarding
+      ssh.cancel();
+      await p;
+      tester.assert(ssh.wasCancelled, `wasCancelled should be true`);
+      done();
+    },
+    { isAsync: true, skip: !real_remote_forward }
+  );
 
-    tester.test('ssh.Ssh (real / execute test3.sh {trim:true,skipBlankLines:true} )', async (done) => {
-        const cmd = getRemoteCmd('test4.sh 5');
-        const ssh = new Ssh('127.0.0.1', cmd, {trim:true,skipBlankLines:true});
-        const result = await ssh.run();
-        tester.assert(result, `execution should succeed`);
-        const stdout = ssh.stdout;
-        const expectedStdout = `2\n4`;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match`);
-        const stderr = ssh.stderr;
-        const expectedStderr = `1\n3\n5`;
-        tester.assertEq(stderr, expectedStderr, `stderr content should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
+  tester.test(
+    'ssh.sshExec (real / execute test8.sh with success)',
+    async (done) => {
+      const cmd = getRemoteCmd('test8.sh OK');
+      const stdout = await sshExec('127.0.0.1', cmd);
+      const expectedStdout = `OK`;
+      tester.assertEq(stdout, expectedStdout, `stdout content should match`);
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (real / execute test7.sh {maxTime:1} )', async (done) => {
-        const cmd = getRemoteCmd('test7.sh 5');
-        const ssh = new Ssh('127.0.0.1', cmd, {maxTime:1});
-        const result = await ssh.run();
-        tester.assert(!result, `execution should fail`);
-        tester.assert(ssh.failed, `failed should be true`);
-        tester.assert(!ssh.sshFailed, `sshFailed should be false`);
-        tester.assertEq(ssh.sshError, undefined, `sshError should be undefined`);
-        tester.assertEq(ssh.sshErrorReason, undefined, `sshErrorReason should be undefined`);
-        tester.assert(ssh.commandFailed, `commandFailed should be true`);
-        tester.assert(ssh.didTimeout, `didTimeout should be true`);
-        tester.assert(!ssh.wasCancelled, `wasCancelled should be false`);
-        const state = ssh.state;
-        tester.assertEq(state.exitCode, -os.SIGTERM, `exitCode should match`);
-        tester.assertEq(state.signal, 'SIGTERM', `signal should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
+  tester.test(
+    'ssh.sshExec (real / execute test2.sh with non-zero exit code)',
+    async (done) => {
+      const cmd = getRemoteCmd('test2.sh 5 3');
+      const expectedStderr = `135`;
+      try {
+        await sshExec('127.0.0.1', cmd);
+        tester.assert(false, `an exception should have been thrown`);
+      } catch (e) {
+        tester.assertNeq(
+          e.state,
+          undefined,
+          `exception.state should be defined`
+        );
+        tester.assertEq(
+          e.sshError,
+          undefined,
+          `exception.sshError should be undefined`
+        );
+        tester.assertEq(
+          e.sshErrorReason,
+          undefined,
+          `exception.sshErrorReason should be undefined`
+        );
+        tester.assertEq(
+          e.message,
+          expectedStderr,
+          `exception.message should match`
+        );
+      }
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
 
-    tester.test('ssh.Ssh (real / execute test7.sh and cancel)', async (done) => {
-        const cmd = getRemoteCmd('test7.sh 5');
-        const ssh = new Ssh('127.0.0.1', cmd);
-        const p = ssh.run();
-        await wait(500);
-        ssh.cancel();
-        const result = await p;
-        tester.assert(!result, `execution should fail`);
-        tester.assert(ssh.failed, `failed should be true`);
-        tester.assert(!ssh.sshFailed, `sshFailed should be false`);
-        tester.assertEq(ssh.sshError, undefined, `sshError should be undefined`);
-        tester.assertEq(ssh.sshErrorReason, undefined, `sshErrorReason should be undefined`);
-        tester.assert(ssh.commandFailed, `commandFailed should be true`);
-        tester.assert(!ssh.didTimeout, `didTimeout should be false`);
-        tester.assert(ssh.wasCancelled, `wasCancelled should be true`);
-        const state = ssh.state;
-        tester.assertEq(state.exitCode, -os.SIGINT, `exitCode should match`);
-        tester.assertEq(state.signal, 'SIGINT', `signal should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
-
-    tester.test('ssh.Ssh (real / execute test2.sh with event listeners {lineBuffered:false} )', async (done) => {
-        const cmd = getRemoteCmd('test2.sh 5');
-        const ssh = new Ssh('127.0.0.1', cmd, {lineBuffered:false});
-        let stdout = '', stderr = '';
-        ssh.setEventListener('stdout', (obj) => {
-            stdout += obj.data;
-        });
-        ssh.setEventListener('stderr', (obj) => {
-            stderr += obj.data;
-        });
-        const result = await ssh.run();
-        tester.assert(result, `execution should succeed`);
-        const expectedStdout = `24\n`;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match`);
-        const expectedStderr = `135\n`;
-        tester.assertEq(stderr, expectedStderr, `stderr content should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
-
-    tester.test('ssh.Ssh (real / execute test2.sh with event listeners {lineBuffered:true} )', async (done) => {
-        const cmd = getRemoteCmd('test2.sh 5');
-        const ssh = new Ssh('127.0.0.1', cmd, {lineBuffered:true});
-        let stdout = '', stderr = '';
-        ssh.setEventListener('stdout', (obj) => {
-            stdout += obj.data;
-        });
-        ssh.setEventListener('stderr', (obj) => {
-            stderr += obj.data;
-        });
-        const result = await ssh.run();
-        tester.assert(result, `execution should succeed`);
-        const expectedStdout = `24`;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match`);
-        const expectedStderr = `135`;
-        tester.assertEq(stderr, expectedStderr, `stderr content should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
-
-    tester.test('ssh.Ssh (real / execute test1.sh {pseudoTerminal:true,normalizeEol:false} )', async (done) => {
-        const cmd = getRemoteCmd('test1.sh 5');
-        const ssh = new Ssh('127.0.0.1', cmd, {pseudoTerminal:true});
-        const result = await ssh.run();
-        tester.assert(result, `execution should succeed`);
-        const stdout = ssh.stdout;
-        const expectedStdout = `1\r\n2\r\n3\r\n4\r\n5`;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match`);
-        const stderr = ssh.stderr;
-        // when using pseudo terminal, stderr will be redirected to stdout by OpenSSH
-        const expectedStderr = '';
-        tester.assertEq(stderr, expectedStderr, `stderr content should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
-
-    tester.test('ssh.Ssh (real / execute test1.sh {pseudoTerminal:true,normalizeEol:true} )', async (done) => {
-        const cmd = getRemoteCmd('test1.sh 5');
-        const ssh = new Ssh('127.0.0.1', cmd, {pseudoTerminal:true,normalizeEol:true});
-        const result = await ssh.run();
-        tester.assert(result, `execution should succeed`);
-        const stdout = ssh.stdout;
-        const expectedStdout = `1\n2\n3\n4\n5`;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match`);
-        const stderr = ssh.stderr;
-        // when using pseudo terminal, stderr will be redirected to stdout by OpenSSH
-        const expectedStderr = '';
-        tester.assertEq(stderr, expectedStderr, `stderr content should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
-
-    tester.test('ssh.Ssh (real / execute test5.sh without environment variables)', async (done) => {
-        const cmd = getRemoteCmd('test5.sh');
-        const ssh = new Ssh('127.0.0.1', cmd);
-        const result = await ssh.run();
-        tester.assert(result, `execution should succeed`);
-        const stdout = ssh.stdout;
-        const expectedStdout = `DUMMY_VAR1=\nDUMMY_VAR2=`;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match`);
-        const stderr = ssh.stderr;
-        const expectedStderr = '';
-        tester.assertEq(stderr, expectedStderr, `stderr content should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
-
-    tester.test('ssh.Ssh (real / execute test5.sh with environment variables)', async (done) => {
-        const cmd = getRemoteCmd('test5.sh');
-        const ssh = new Ssh('127.0.0.1', cmd, {
-            env:{'DUMMY_VAR1':1, 'DUMMY_VAR2':2}
-        });
-        const result = await ssh.run();
-        tester.assert(result, `execution should succeed`);
-        const stdout = ssh.stdout;
-        const expectedStdout = `DUMMY_VAR1=1\nDUMMY_VAR2=2`;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match`);
-        const stderr = ssh.stderr;
-        const expectedStderr = '';
-        tester.assertEq(stderr, expectedStderr, `stderr content should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
-
-    tester.test('ssh.Ssh (real / local port forwarding  [local:10001 => remote:22, local:10002 => remote:22])', async (done) => {
-        const ssh = new Ssh('127.0.0.1', '', {
-            localForward:[
-                {remoteAddr:'127.0.0.1', remotePort:22, localPort:10001},
-                {remoteAddr:'127.0.0.1', remotePort:22, localPort:10002}
-            ]
-        });
-        let result, stdout;
-        const p = ssh.run();
-        result = await ssh.waitForSessionSetup();
-        tester.assert(result, `session setup should succeed`);
-        const cmd = getRemoteCmd('test7.sh');
-        const expectedStdout = 'OK';
-        const ssh1 = new Ssh('127.0.0.1', cmd, {port:10001});
-        result = await ssh1.run();
-        tester.assert(result, `execution using local port 10001 should succeed`);
-        stdout = ssh1.stdout;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match when using local port 10001`);
-        const ssh2 = new Ssh('127.0.0.1', cmd, {port:10002});
-        result = await ssh2.run();
-        tester.assert(result, `execution using local port 10002 should succeed`);
-        stdout = ssh2.stdout;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match when using local port 10002`);
-        // stop forwarding
-        ssh.cancel();
-        await p;
-        tester.assert(ssh.wasCancelled, `wasCancelled should be true`);
-        done();
-    }, {isAsync:true, skip:!real_local_forward});
-    
-    tester.test('ssh.Ssh (real / remote port forwarding  [remote:10001 => local:22, remote:10002 => local:22])', async (done) => {
-        const ssh = new Ssh('127.0.0.1', '', {
-            remoteForward:[
-                {remoteAddr:'127.0.0.1', remotePort:10001, localPort:22},
-                {remoteAddr:'127.0.0.1', remotePort:10002, localPort:22}
-            ]
-        });
-        let result, stdout;
-        const p = ssh.run();
-        result = await ssh.waitForSessionSetup();
-        tester.assert(result, `session setup should succeed`);
-        tester.assertEq(ssh.remotePorts, undefined, `remotePorts should be undefined`);
-        const cmd = getRemoteCmd('test7.sh');
-        const expectedStdout = 'OK';
-        const ssh1 = new Ssh('127.0.0.1', cmd, {port:10001});
-        result = await ssh1.run();
-        tester.assert(result, `execution using remote port 10001 should succeed`);
-        stdout = ssh1.stdout;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match when using remote port 10001`);
-        const ssh2 = new Ssh('127.0.0.1', cmd, {port:10002});
-        result = await ssh2.run();
-        tester.assert(result, `execution using port 10002 should succeed`);
-        stdout = ssh2.stdout;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match when using remote port 10002`);
-        // stop forwarding
-        ssh.cancel();
-        await p;
-        tester.assert(ssh.wasCancelled, `wasCancelled should be true`);
-        done();
-    }, {isAsync:true, skip:!real_remote_forward});
-
-    tester.test('ssh.Ssh (real / remote port forwarding  [remote:? => local:22])', async (done) => {
-        const ssh = new Ssh('127.0.0.1', '', {
-            remoteForward:[
-                {remoteAddr:'127.0.0.1', localPort:22}
-            ]
-        });
-        let result, stdout;
-        const p = ssh.run();
-        result = await ssh.waitForSessionSetup();
-        tester.assert(result, `session setup should succeed`);
-        const remotePorts = ssh.remotePorts;
-        tester.assertNeq(remotePorts, undefined, `remotePorts should not be undefined`);
-        tester.assertEq(remotePorts.length, 1, `size of remotePorts should be as expected`);
-        let dynamicPort = '?';
-        if (undefined !== remotePorts) {
-            dynamicPort = remotePorts[0].remotePort;
-        }
-        const cmd = getRemoteCmd('test7.sh');
-        const expectedStdout = 'OK';
-        const ssh1 = new Ssh('127.0.0.1', cmd, {port:dynamicPort});
-        result = await ssh1.run();
-        tester.assert(result, `execution using dynamically allocated remote port ${dynamicPort} should succeed`);
-        stdout = ssh1.stdout;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match when using dynamically allocated remote port`);
-        // stop forwarding
-        ssh.cancel();
-        await p;
-        tester.assert(ssh.wasCancelled, `wasCancelled should be true`);
-        done();
-    }, {isAsync:true, skip:!real_remote_forward});
-
-    tester.test('ssh.sshExec (real / execute test8.sh with success)', async (done) => {
-        const cmd = getRemoteCmd('test8.sh OK');
-        const stdout = await sshExec('127.0.0.1', cmd);
-        const expectedStdout = `OK`;
-        tester.assertEq(stdout, expectedStdout, `stdout content should match`);
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
-    
-    tester.test('ssh.sshExec (real / execute test2.sh with non-zero exit code)', async (done) => {
-        const cmd = getRemoteCmd('test2.sh 5 3');
-        const expectedStderr = `135`;
-        try {
-            await sshExec('127.0.0.1', cmd);
-            tester.assert(false, `an exception should have been thrown`);
-        }
-        catch (e) {
-            tester.assertNeq(e.state, undefined, `exception.state should be defined`);
-            tester.assertEq(e.sshError, undefined, `exception.sshError should be undefined`);
-            tester.assertEq(e.sshErrorReason, undefined, `exception.sshErrorReason should be undefined`);
-            tester.assertEq(e.message, expectedStderr, `exception.message should match`);
-        }
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
-
-    tester.test('ssh.multiSsh (real / execute test8.sh 3 times in parallel)', async (done) => {
-        const list = [];
-        for (let i = 0; i < 3; ++i) {
-            list.push(new Ssh('127.0.0.1', getRemoteCmd(`test8.sh ${i}`)));
-        }
-        const responses = (await multiSsh(list)).map((e => e.ssh.stdout));
-        for (let i = 0; i < 3; ++i) {
-            const expectedStdout = `${i}`;
-            tester.assertEq(responses[i], expectedStdout, `stdout content should match for execution #${i+1}`);
-        }
-        done();
-    }, {isAsync:true, skip:!real_ssh_connect});
-
-}
+  tester.test(
+    'ssh.multiSsh (real / execute test8.sh 3 times in parallel)',
+    async (done) => {
+      const list = [];
+      for (let i = 0; i < 3; ++i) {
+        list.push(new Ssh('127.0.0.1', getRemoteCmd(`test8.sh ${i}`)));
+      }
+      const responses = (await multiSsh(list)).map((e) => e.ssh.stdout);
+      for (let i = 0; i < 3; ++i) {
+        const expectedStdout = `${i}`;
+        tester.assertEq(
+          responses[i],
+          expectedStdout,
+          `stdout content should match for execution #${i + 1}`
+        );
+      }
+      done();
+    },
+    { isAsync: true, skip: !real_ssh_connect }
+  );
+};

--- a/test/tests/test.strings.js
+++ b/test/tests/test.strings.js
@@ -1,10 +1,9 @@
 /** @format */
 // @ts-check
 
-// @ts-ignore
-import * as os from 'os';
-// @ts-ignore
-import * as std from 'std';
+import * as std from '../../src/std.js';
+import * as os from '../../src/os.js';
+import { notNull } from '../../src/types.js';
 
 import { tester } from '../../src/tester.js';
 import {
@@ -29,7 +28,7 @@ export default () => {
     // call method without the expected length
     const contentFromBuffer = bytesArrayToStr(buffer).trim();
     // read file using std
-    const content = std.loadFile(filepath).trim();
+    const content = notNull(std.loadFile(filepath)).trim();
     tester.assert(
       contentFromBuffer.length == content.length,
       `converted buffer should have a length of ${content.length} (${contentFromBuffer.length})`
@@ -70,7 +69,7 @@ export default () => {
         to: len,
       }).trim();
       // read file using std
-      const content = std.loadFile(filepath).trim();
+      const content = notNull(std.loadFile(filepath)).trim();
       tester.assert(
         contentFromBuffer.length == content.length,
         `converted buffer (${filepath}) should have a length of ${content.length} (${contentFromBuffer.length})`
@@ -150,7 +149,7 @@ export default () => {
     const fd = os.open(filepath);
     // @ts-ignore
     const len = os.read(fd, initialBuffer.buffer, 0, initialBuffer.length);
-    const file = std.open('data/file2.txt', 'r');
+    const file = notNull(std.open('data/file2.txt', 'r'));
     const content = file.readAsString();
     const convertedBuffer = strToBytesArray(content);
     // in case we don't have a match, identify first non-matching character

--- a/test/tests/test.timers.js
+++ b/test/tests/test.timers.js
@@ -1,31 +1,43 @@
+/** @format */
+
 import * as os from 'os';
 import { tester } from '../../src/tester.js';
-import { wait, setInterval, clearInterval } from '../../src/timers.js'
+import { wait, setInterval, clearInterval } from '../../src/timers.js';
 
 export default () => {
+  tester.test(
+    'timers.wait',
+    async (done) => {
+      const startTs = Date.now();
+      await wait(1000);
+      const endTs = Date.now();
+      const delta = endTs - startTs;
+      tester.assert(delta >= 1000, `it should wait =~ 1s (${delta}ms)`);
+      done();
+    },
+    { isAsync: true }
+  );
 
-    tester.test('timers.wait', async (done) => {
-        const startTs = Date.now();
-        await wait(1000);
-        const endTs = Date.now();
-        const delta = endTs - startTs;
-        tester.assert(delta >= 1000, `it should wait =~ 1s (${delta}ms)`);
-        done();
-    }, {isAsync:true});
-
-    tester.test('timers.setInterval', async (done) => {
-        let counter = 0;
-        const timer = setInterval(() => {
-            ++counter;
-        }, 250);
+  tester.test(
+    'timers.setInterval',
+    async (done) => {
+      let counter = 0;
+      const timer = setInterval(() => {
+        ++counter;
+      }, 250);
+      os.setTimeout(() => {
+        clearInterval(timer);
+        tester.assert(counter >= 4, `counter should be >= 4 (${counter})`);
+        const prevCounter = counter;
         os.setTimeout(() => {
-            clearInterval(timer);
-            tester.assert(counter >= 4, `counter should be >= 4 (${counter})`);
-            const prevCounter = counter;
-            os.setTimeout(() => {
-                tester.assert(counter == prevCounter, `counter should be == ${prevCounter} after clearing interval (${counter})`);
-                done();
-            }, 500);
-        }, 1250);
-    }, {isAsync:true});
-}
+          tester.assert(
+            counter == prevCounter,
+            `counter should be == ${prevCounter} after clearing interval (${counter})`
+          );
+          done();
+        }, 500);
+      }, 1250);
+    },
+    { isAsync: true }
+  );
+};

--- a/test/tests/test.version.js
+++ b/test/tests/test.version.js
@@ -1,132 +1,178 @@
+/** @format */
+
 import { tester } from '../../src/tester.js';
-import { version } from '../../src/version.js'
+import { version } from '../../src/version.js';
 
 export default () => {
+  tester.test('version (lib version)', () => {
+    tester.assert(
+      undefined !== version.VERSION,
+      `lib version should be defined`
+    );
+  });
 
-    tester.test('version (lib version)', () => {
-        tester.assert(undefined !== version.VERSION, `lib version should be defined`);
+  tester.test('version (semver)', () => {
+    ['1.0.0', '1.0.0-alpha', '1.0.0-0.3.7+exp.sha.5114f85'].forEach((v) => {
+      tester.assert(
+        version.isSemver(v),
+        `'${v}' should be a valid semver version`
+      );
+      const converted = version.convert(v);
+      tester.assertEq(
+        converted,
+        v,
+        `'${v}' should remain unchanged after conversion`
+      );
     });
+  });
 
-    tester.test('version (semver)', () => {
-        ['1.0.0', '1.0.0-alpha', '1.0.0-0.3.7+exp.sha.5114f85'].forEach((v) => {
-            tester.assert(version.isSemver(v), `'${v}' should be a valid semver version`);
-            const converted = version.convert(v);
-            tester.assertEq(converted, v, `'${v}' should remain unchanged after conversion`);
-        });
+  tester.test('version (non semver)', () => {
+    [
+      version.eq,
+      version.neq,
+      version.lt,
+      version.lte,
+      version.gt,
+      version.gte,
+    ].forEach((fn) => {
+      let exception;
+      try {
+        fn('a.b.c');
+      } catch (e) {
+        exception = e;
+      }
+      tester.assert(
+        undefined !== exception,
+        `'${fn.name}' should throw an exception when using a non semver version as first argument`
+      );
+      exception = undefined;
+      try {
+        fn('1.0.0', 'a.b.c');
+      } catch (e) {
+        exception = e;
+      }
+      tester.assert(
+        undefined !== exception,
+        `'${fn.name}' should throw an exception when using a non semver version as second argument`
+      );
     });
-
-    tester.test('version (non semver)', () => {
-        [version.eq, version.neq, version.lt, version.lte, version.gt, version.gte].forEach((fn) => {
-            let exception;
-            try {
-                fn('a.b.c');
-            }
-            catch (e) {
-                exception = e;
-            }
-            tester.assert(undefined !== exception, `'${fn.name}' should throw an exception when using a non semver version as first argument`);
-            exception = undefined;
-            try {
-                fn('1.0.0', 'a.b.c');
-            }
-            catch (e) {
-                exception = e;
-            }
-            tester.assert(undefined !== exception, `'${fn.name}' should throw an exception when using a non semver version as second argument`);
-        });
-        [
-            {from:'1.0.0a', to:'1.0.0'},
-            {from:'1.0.0-a@b', to:'1.0.0'},
-            {from:'1.0.0-alpha+a@b', to:'1.0.0'},
-        ].forEach((e) => {
-            tester.assert(!version.isSemver(e.from), `'${e.from}' should not be a valid semver version`);
-            const converted = version.convert(e.from);
-            tester.assertEq(converted, e.to, `'${e.from}' should be converted to '${e.to}'`);
-        });
+    [
+      { from: '1.0.0a', to: '1.0.0' },
+      { from: '1.0.0-a@b', to: '1.0.0' },
+      { from: '1.0.0-alpha+a@b', to: '1.0.0' },
+    ].forEach((e) => {
+      tester.assert(
+        !version.isSemver(e.from),
+        `'${e.from}' should not be a valid semver version`
+      );
+      const converted = version.convert(e.from);
+      tester.assertEq(
+        converted,
+        e.to,
+        `'${e.from}' should be converted to '${e.to}'`
+      );
     });
+  });
 
-    tester.test('version (eq)', () => {
-        let current = '1.0.0';
-        const target = '1.0.0';
-        tester.assert(version.eq(target, current), `${current} == ${target}`);
-        current = '1.0.1';
-        tester.assert(!version.eq(target, current), `not (${current} == ${target})`);
-    });
+  tester.test('version (eq)', () => {
+    let current = '1.0.0';
+    const target = '1.0.0';
+    tester.assert(version.eq(target, current), `${current} == ${target}`);
+    current = '1.0.1';
+    tester.assert(
+      !version.eq(target, current),
+      `not (${current} == ${target})`
+    );
+  });
 
-    tester.test('version (neq)', () => {
-        let current = '1.0.1';
-        const target = '1.0.0';
-        tester.assert(version.neq(target, current), `${current} != ${target}`);
-        current = '1.0.0';
-        tester.assert(!version.neq(target, current), `not (${current} != ${target})`);
-    });
+  tester.test('version (neq)', () => {
+    let current = '1.0.1';
+    const target = '1.0.0';
+    tester.assert(version.neq(target, current), `${current} != ${target}`);
+    current = '1.0.0';
+    tester.assert(
+      !version.neq(target, current),
+      `not (${current} != ${target})`
+    );
+  });
 
-    tester.test('version (lt)', () => {
-        let current = '1.0.0';
-        let target = '1.0.1';
-        tester.assert(version.lt(target, current), `${current} < ${target}`);
-        current = '1.0.1';
-        tester.assert(!version.lt(target, current), `not (${current} < ${target})`);
-        current = '1.0.2';
-        tester.assert(!version.lt(target, current), `not (${current} < ${target})`);
-        target = '0.5.0';
-        current = '0.4.0';
-        tester.assert(version.lt(target, current), `${current} < ${target}`);
-        current = '0.5.0';
-        tester.assert(!version.lt(target, current), `not (${current} < ${target})`);
-        current = '0.6.0';
-        tester.assert(!version.lt(target, current), `not (${current} < ${target})`);
-    });
+  tester.test('version (lt)', () => {
+    let current = '1.0.0';
+    let target = '1.0.1';
+    tester.assert(version.lt(target, current), `${current} < ${target}`);
+    current = '1.0.1';
+    tester.assert(!version.lt(target, current), `not (${current} < ${target})`);
+    current = '1.0.2';
+    tester.assert(!version.lt(target, current), `not (${current} < ${target})`);
+    target = '0.5.0';
+    current = '0.4.0';
+    tester.assert(version.lt(target, current), `${current} < ${target}`);
+    current = '0.5.0';
+    tester.assert(!version.lt(target, current), `not (${current} < ${target})`);
+    current = '0.6.0';
+    tester.assert(!version.lt(target, current), `not (${current} < ${target})`);
+  });
 
-    tester.test('version (lte)', () => {
-        let current = '1.0.0';
-        let target = '1.0.1';
-        tester.assert(version.lte(target, current), `${current} <= ${target}`);
-        current = '1.0.1';
-        tester.assert(version.lte(target, current), `${current} <= ${target}`);
-        current = '1.0.2';
-        tester.assert(!version.lte(target, current), `not (${current} <= ${target})`);
-        target = '0.5.0';
-        current = '0.4.0';
-        tester.assert(version.lte(target, current), `${current} <= ${target}`);
-        current = '0.5.0';
-        tester.assert(version.lte(target, current), `${current} <= ${target}`);
-        current = '0.6.0';
-        tester.assert(!version.lte(target, current), `not (${current} <= ${target})`);
-    });
+  tester.test('version (lte)', () => {
+    let current = '1.0.0';
+    let target = '1.0.1';
+    tester.assert(version.lte(target, current), `${current} <= ${target}`);
+    current = '1.0.1';
+    tester.assert(version.lte(target, current), `${current} <= ${target}`);
+    current = '1.0.2';
+    tester.assert(
+      !version.lte(target, current),
+      `not (${current} <= ${target})`
+    );
+    target = '0.5.0';
+    current = '0.4.0';
+    tester.assert(version.lte(target, current), `${current} <= ${target}`);
+    current = '0.5.0';
+    tester.assert(version.lte(target, current), `${current} <= ${target}`);
+    current = '0.6.0';
+    tester.assert(
+      !version.lte(target, current),
+      `not (${current} <= ${target})`
+    );
+  });
 
-    tester.test('version (gt)', () => {
-        let current = '1.0.2';
-        let target = '1.0.1';
-        tester.assert(version.gt(target, current), `${current} > ${target}`);
-        current = '1.0.1';
-        tester.assert(!version.gt(target, current), `not (${current} > ${target})`);
-        current = '1.0.0';
-        tester.assert(!version.gt(target, current), `not (${current} > ${target})`);
-        target = '0.4.0';
-        current = '0.5.0';
-        tester.assert(version.gt(target, current), `${current} > ${target}`);
-        current = '0.4.0';
-        tester.assert(!version.gt(target, current), `not (${current} > ${target})`);
-        current = '0.3.0';
-        tester.assert(!version.gt(target, current), `not (${current} > ${target})`);
-    });
+  tester.test('version (gt)', () => {
+    let current = '1.0.2';
+    let target = '1.0.1';
+    tester.assert(version.gt(target, current), `${current} > ${target}`);
+    current = '1.0.1';
+    tester.assert(!version.gt(target, current), `not (${current} > ${target})`);
+    current = '1.0.0';
+    tester.assert(!version.gt(target, current), `not (${current} > ${target})`);
+    target = '0.4.0';
+    current = '0.5.0';
+    tester.assert(version.gt(target, current), `${current} > ${target}`);
+    current = '0.4.0';
+    tester.assert(!version.gt(target, current), `not (${current} > ${target})`);
+    current = '0.3.0';
+    tester.assert(!version.gt(target, current), `not (${current} > ${target})`);
+  });
 
-    tester.test('version (gte)', () => {
-        let current = '1.0.2';
-        let target = '1.0.1';
-        tester.assert(version.gte(target, current), `${current} >= ${target}`);
-        current = '1.0.1';
-        tester.assert(version.gte(target, current), `${current} >= ${target}`);
-        current = '1.0.0';
-        tester.assert(!version.gte(target, current), `not (${current} >= ${target})`);
-        target = '0.4.0';
-        current = '0.5.0';
-        tester.assert(version.gte(target, current), `${current} >= ${target}`);
-        current = '0.4.0';
-        tester.assert(version.gte(target, current), `${current} >= ${target}`);
-        current = '0.3.0';
-        tester.assert(!version.gte(target, current), `not (${current} >= ${target})`);
-     });
-
-}
+  tester.test('version (gte)', () => {
+    let current = '1.0.2';
+    let target = '1.0.1';
+    tester.assert(version.gte(target, current), `${current} >= ${target}`);
+    current = '1.0.1';
+    tester.assert(version.gte(target, current), `${current} >= ${target}`);
+    current = '1.0.0';
+    tester.assert(
+      !version.gte(target, current),
+      `not (${current} >= ${target})`
+    );
+    target = '0.4.0';
+    current = '0.5.0';
+    tester.assert(version.gte(target, current), `${current} >= ${target}`);
+    current = '0.4.0';
+    tester.assert(version.gte(target, current), `${current} >= ${target}`);
+    current = '0.3.0';
+    tester.assert(
+      !version.gte(target, current),
+      `not (${current} >= ${target})`
+    );
+  });
+};


### PR DESCRIPTION
* refactor: add *JSDoc* support for `os` and `std` modules
* refactor: replace `os` and `std` imports with `./os.js` and `./std.js` to get completion
* refactor: ensure `// @ts-check` is set in `.js` files
* feat: add `notNull` function to simulate `!` typescript operator (*non-null* assertion) (`types.js`)