### PR TITLE
fix: fix "typo" when doing completion

### DIFF
--- a/src/internal/completion.js
+++ b/src/internal/completion.js
@@ -447,7 +447,7 @@ export const completeCmdLine = async (
           // without an ArgValidator we can do path completion
           if (!(argValidator instanceof ArgValidator)) {
             debug(() => `Path completion (${output.argName}) from ''`);
-            completions = ['@@QEL_PATH@@'];
+            completions = ['@QEL_PATH@'];
           } else {
             debug(
               () => `Argument value completion (${output.argName}) from ''`
@@ -539,7 +539,7 @@ export const completeCmdLine = async (
               () =>
                 `Path completion (${output.argName}) from '${curToken.content}'`
             );
-            completions = ['@@QEL_PATH@@'];
+            completions = ['@QEL_PATH@'];
           } else {
             debug(
               () =>


### PR DESCRIPTION
Hi. It looks like a typo because in every other place `@` is used instead of `@@`. As a result, the [example completion functions](https://github.com/ctn-malone/qjs-ext-lib/blob/master/doc/arg.md#completion-functions) do not work, because `@@QEL_PATH@@` is returned while `@QEL_PATH@` is expected 