### PR TITLE
chore: version 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Change Log
 
-## [0.14.3] **WIP**
+## [0.15.0]
 * chore: update `flake.nix` template
 * chore: add a _shebang_ to script templates
-* chore: indicate whether or not a script supports completion
+* chore: indicate whether or not a script supports completion in `qel.config.json`
+* chore: update `quickjs-cross-compiler` version in `flake.nix`
+* chore: add `qel-completion.sh` script to generate completion for both `bash` and `zsh`
+* chore: setup shell completion when entering `nix develop` shell
 * fix: fix `qel-upgrade.sh` script
+* fix: close file handle after ensuring a file exists (`args.js`)
+* fix: escape `:` when generating completions for `zsh`
+* refactor: make `errno` optional in `errorObj` (`std.js`, `os.js`)
   
 ## [0.14.2]
 * fix: fix `getScriptDir` function for compiled scripts (`path.js`)

--- a/bootstrap/bootstrap.js
+++ b/bootstrap/bootstrap.js
@@ -51,10 +51,13 @@ const args = arg
   });
 
 const repoRoot = ui.ensureGitRepo(args.get('--dir'));
+ui.ensureGitIgnore(repoRoot, '.gitignore', ['/result']);
+
 const configPath = ui.ensureConfig(
   repoRoot,
   /** @type {string} */ (templatesRootDir)
 );
+
 const script = ui.addScript(
   repoRoot,
   configPath,

--- a/bootstrap/generate-completion.js
+++ b/bootstrap/generate-completion.js
@@ -1,0 +1,193 @@
+/** @format */
+// @ts-check
+import * as std from './ext/std.js';
+import * as os from './ext/os.js';
+
+import arg from './ext/arg.js';
+import * as config from './lib/config.js';
+import * as git from './lib/git.js';
+import { CONFIG_FILE_NAME } from './lib/config.js';
+import { highlight } from './lib/style.js';
+import { notNull } from './ext/types.js';
+
+/*
+  This script is meant to be called from within a nix shell
+  It relies on two environment variables to work properly
+
+  - QEL_TEMPLATES_ROOT_DIR: full path to the root directory containing templates, inside nix store
+ */
+
+const SCRIPT_NAME = 'qel-completion.sh';
+
+const DEFAULT_FUNCTION_NAME = '_qel_completion';
+
+const templatesRootDir = std.getenv('QEL_TEMPLATES_ROOT_DIR');
+if (!templatesRootDir) {
+  std.err.puts(
+    `Missing ${highlight('QEL_TEMPLATES_ROOT_DIR')} environment variable\n`
+  );
+  std.exit(2);
+}
+
+const args = arg
+  .parser({
+    '--config': arg
+      .path()
+      .check()
+      .desc(
+        `path to the '${CONFIG_FILE_NAME}' file (by default, use the '${CONFIG_FILE_NAME}' file at the root of the git repository)`
+      ),
+    '--shell': arg
+      .str('bash')
+      .enum(['bash', 'zsh'])
+      .desc('shell to generate completion for')
+      .env('QEL_COMPLETION_SHELL')
+      .val('NAME'),
+    '--function-name': arg
+      .str(DEFAULT_FUNCTION_NAME)
+      .env('QEL_COMPLETION_FUNCTION_NAME')
+      .val('NAME')
+      .desc('name of the shell function used for completion')
+      .cust((value) => {
+        if (!value.startsWith('_')) {
+          throw new Error(`function name should start with "_"`);
+        }
+      }),
+    '--randomize-function-name': arg
+      .flag(true)
+      .env('QEL_COMPLETION_RANDOMIZE_FUNCTION_NAME')
+      .desc(
+        'if set, a randomize value will be added at the end of the function name'
+      ),
+    '--function': arg
+      .flag(true)
+      .desc('if set, output completion function')
+      .env('QEL_COMPLETION_ENABLE_FUNCTION'),
+    '--setup': arg
+      .flag(true)
+      .desc('if set, output completion setup for each script')
+      .env('QEL_COMPLETION_ENABLE_SETUP'),
+    '--release': arg
+      .flag(true)
+      .desc(
+        'if set, output completion setup for "release" (ie: compiled) scripts (ignored if --setup is not set'
+      )
+      .env('QEL_COMPLETION_SETUP_FOR_RELEASE'),
+    '--dev': arg
+      .flag()
+      .desc(
+        'if set, output completion setup for "dev" (ie: .js) scripts (ignored if --setup is not set'
+      )
+      .env('QEL_COMPLETION_SETUP_FOR_DEV'),
+    '-c': '--config',
+    '-s': '--shell',
+  })
+  .ex([
+    '-s zsh',
+    '-s zsh --dev',
+    '--function-name _my_completion_function',
+    '--no-setup',
+  ])
+  .desc('Output shell completion to stdout')
+  .parse({
+    scriptName: SCRIPT_NAME,
+  });
+
+// @ts-ignore
+let configFilePath = args.get('--config');
+if (!configFilePath) {
+  const curDir = os.getcwd()[0];
+  try {
+    const repoRoot = git.getRoot(curDir);
+    configFilePath = `${repoRoot}/${CONFIG_FILE_NAME}`;
+  } catch (e) {
+    std.err.puts(e.message);
+    std.exit(2);
+  }
+}
+if (!os.stat(configFilePath)[0]) {
+  std.err.puts(`Config file ${configFilePath} does not exist`);
+  std.exit(2);
+}
+
+if (!args.get('--setup') && !args.get('--function')) {
+  args.usage(`At least one of (--function, --setup) should be set`);
+}
+
+/**
+ * @param {'bash' | 'zsh'} shell
+ * @param {string} functionName
+ *
+ * @returns {string}
+ */
+const generateFunction = (shell, functionName) => {
+  let filepath = `${templatesRootDir}/completion/function.bash`;
+  if (shell === 'zsh') {
+    filepath = `${templatesRootDir}/completion/function.zsh`;
+  }
+  let content = notNull(std.loadFile(filepath)).trim();
+  // replace function name
+  content = content.replace(`${DEFAULT_FUNCTION_NAME}()`, `${functionName}()`);
+  return content;
+};
+
+/**
+ * @param {'bash' | 'zsh'} shell
+ * @param {string} functionName
+ * @param {string[]} commands
+ *
+ * @returns {string}
+ */
+const generateSetup = (shell, functionName, commands) => {
+  const lines = commands.map((command) => {
+    if (shell === 'zsh') {
+      return `compdef ${functionName} ${command}`;
+    }
+    return `complete -F ${functionName} ${command}`;
+  });
+  return lines.join('\n');
+};
+
+const main = async () => {
+  const cfg = config.loadConfig(configFilePath);
+
+  /** @type {string[]} */
+  const commands = [];
+  for (const script of cfg.scripts) {
+    if (script.completion !== true) {
+      continue;
+    }
+    if (args.get('--dev')) {
+      commands.push(script.file);
+    }
+    if (args.get('--release')) {
+      commands.push(script.name);
+    }
+  }
+  if (!commands.length) {
+    std.exit(0);
+  }
+
+  let functionName = args.get('--function-name');
+  if (args.get('--randomize-function-name')) {
+    functionName += `_${Date.now()}`;
+  }
+
+  let content = '';
+  if (args.get('--function')) {
+    content += `\n${generateFunction(args.get('--shell'), functionName)}\n`;
+  }
+  if (args.get('--setup')) {
+    content += `\n${generateSetup(
+      args.get('--shell'),
+      functionName,
+      commands
+    )}\n`;
+  }
+  std.out.puts(`${content.trim()}\n`);
+  std.exit(0);
+};
+main().catch((e) => {
+  std.err.puts(e.message);
+  std.exit(1);
+});

--- a/bootstrap/lib/config.js
+++ b/bootstrap/lib/config.js
@@ -64,7 +64,7 @@ export const loadConfig = (configPath) => {
   const configFile = std.open(configPath, 'r', errObj);
   if (errObj !== undefined) {
     throw new Error(
-      `Could not open '${configPath}' for reading/writing (${std.strerror(
+      `Could not open '${configPath}' for reading (${std.strerror(
         errObj.errno
       )})`
     );

--- a/bootstrap/templates/completion/function.bash
+++ b/bootstrap/templates/completion/function.bash
@@ -1,0 +1,35 @@
+_qel_completion() {
+  local IFS=$'\n'
+
+  local cur prev words cword
+  _get_comp_words_by_ref -n : cur prev words cword
+
+  # command which triggered the completion
+  local cmd=${words[0]}
+  local extension="${cmd##*.}"
+
+  # call command to get completions
+  local output
+  if [[ "${extension}" == 'js' ]]; then
+    output=$(COMP_LINE="${COMP_LINE}" COMP_POINT="${COMP_POINT}" qjs.sh ${cmd})
+  else
+    output=$(COMP_LINE="${COMP_LINE}" COMP_POINT="${COMP_POINT}" ${cmd})
+  fi
+
+  if [[ -n "${output}" ]]; then
+    case "$output" in
+    "@QEL_DIR@")
+      # complete only directories
+      _filedir -d
+      ;;
+    "@QEL_PATH@")
+      # complete files and directories
+      _filedir
+      ;;
+    *)
+      # use completions from command
+      COMPREPLY=($output)
+      ;;
+    esac
+  fi
+}

--- a/bootstrap/templates/completion/function.zsh
+++ b/bootstrap/templates/completion/function.zsh
@@ -1,0 +1,35 @@
+_qel_completion() {
+  # full command line up to cursor position
+  local cmd_line="${BUFFER[1, $CURSOR]}"
+
+  # command which triggered the completion
+  local cmd="${words[1]}"
+  local extension="${cmd##*.}"
+
+  # call command to get completions
+  local output
+  if [[ "${extension}" == 'js' ]]; then
+    output=$(QEL_COMPLETION_SHELL=zsh COMP_LINE="${cmd_line}" COMP_POINT="${CURSOR}" qjs.sh ${cmd})
+  else
+    output=$(QEL_COMPLETION_SHELL=zsh COMP_LINE="${cmd_line}" COMP_POINT="${CURSOR}" ${cmd})
+  fi
+
+  if [[ -n "${output}" ]]; then
+    case "$output" in
+    "@QEL_DIR@")
+      # complete only directories
+      _files -/
+      ;;
+    "@QEL_PATH@")
+      # complete files and directories
+      _files
+      ;;
+    *)
+      # use completions from command
+      local completions=("${(f)${output}}")
+      completions=("${(f)output}")
+      _describe 'completions' completions
+      ;;
+    esac
+  fi
+}

--- a/bootstrap/templates/js/arg.js
+++ b/bootstrap/templates/js/arg.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S qjs.sh --unhandled-rejection -m
+#!/usr/bin/env -S qjs.sh -m
 /** @format */
 // @ts-check
 

--- a/bootstrap/templates/js/arg_curl.js
+++ b/bootstrap/templates/js/arg_curl.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S qjs.sh --unhandled-rejection -m
+#!/usr/bin/env -S qjs.sh -m
 /** @format */
 // @ts-check
 

--- a/bootstrap/templates/js/arg_curl_gum.js
+++ b/bootstrap/templates/js/arg_curl_gum.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S qjs.sh --unhandled-rejection -m
+#!/usr/bin/env -S qjs.sh -m
 /** @format */
 // @ts-check
 

--- a/bootstrap/templates/js/arg_gum.js
+++ b/bootstrap/templates/js/arg_gum.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S qjs.sh --unhandled-rejection -m
+#!/usr/bin/env -S qjs.sh -m
 /** @format */
 // @ts-check
 

--- a/bootstrap/templates/js/curl.js
+++ b/bootstrap/templates/js/curl.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S qjs.sh --unhandled-rejection -m
+#!/usr/bin/env -S qjs.sh -m
 /** @format */
 // @ts-check
 

--- a/bootstrap/templates/js/curl_gum.js
+++ b/bootstrap/templates/js/curl_gum.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S qjs.sh --unhandled-rejection -m
+#!/usr/bin/env -S qjs.sh -m
 /** @format */
 // @ts-check
 

--- a/bootstrap/templates/js/default.js
+++ b/bootstrap/templates/js/default.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S qjs.sh --unhandled-rejection -m
+#!/usr/bin/env -S qjs.sh -m
 /** @format */
 // @ts-check
 

--- a/bootstrap/templates/js/gum.js
+++ b/bootstrap/templates/js/gum.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S qjs.sh --unhandled-rejection -m
+#!/usr/bin/env -S qjs.sh -m
 /** @format */
 // @ts-check
 

--- a/bootstrap/templates/nix/flake.nix
+++ b/bootstrap/templates/nix/flake.nix
@@ -11,49 +11,29 @@
 
   outputs = { self, nixpkgs, flake-utils, qjsExtLib, nixpkgs-gum }:
     flake-utils.lib.eachSystem [ "x86_64-linux" "armv7l-linux" "aarch64-linux" ]
-    (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-        pkgs-gum = nixpkgs-gum.legacyPackages.${system};
-        highlight = text: "\\x1b[1;38;5;212m${text}\\x1b[0m";
-        qel = import (./qel.nix) {
-          pkgs = pkgs;
-          pkgs-gum = pkgs-gum;
-          qjsExtLib = qjsExtLib.packages.${system}.qjs-ext-lib;
-        };
-      in {
-        packages = qel.packages;
-        defaultPackage = qel.defaultPackage;
-        apps = qel.apps;
+      (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          pkgs-gum = nixpkgs-gum.legacyPackages.${system};
+          qel = import (./qel.nix) {
+            pkgs = pkgs;
+            pkgs-gum = pkgs-gum;
+            qjsExtLib = qjsExtLib.packages.${system}.qjs-ext-lib;
+          };
+        in
+        {
+          packages = qel.packages;
+          apps = qel.apps;
 
-        devShell = pkgs.mkShell {
-          name = qel.package.name;
+          devShell = pkgs.mkShell {
+            name = qel.package.name;
 
-          buildInputs = [ qjsExtLib.packages.${system}.qjs-ext-lib ]
-            ++ qel.allRuntimeDeps;
+            buildInputs = [ qjsExtLib.packages.${system}.qjs-ext-lib ]
+              ++ qel.allRuntimeDeps;
 
-          shellHook = ''
-            if [ -d src ]
-            then
-              dir="$(pwd)"
-              cd src && qel-symlink.sh --quiet
-              cd "$dir"
-            fi
-            echo -e "To compile a script, use ${
-              highlight "qjsc.sh -o <binary> <source>"
-            } (ex: ${
-              highlight "qjsc.sh -o /tmp/my-script ./src/my-script.js"
-            })" 1>&2
-            echo -e "To run a script, use ${
-              highlight "qjs.sh <source>"
-            } (ex: ${highlight "qjs.sh ./src/my-script.js"}) or ${
-              highlight "<source>"
-            } (ex: ${highlight "./src/my-script.js"})" 1>&2
-            echo -e "To add a script, use ${highlight "qel-bootstrap.sh"}" 1>&2
-            echo -e "To upgrade the ${highlight "qjs-ext-lib"} version, use ${
-              highlight "qel-upgrade.sh"
-            }" 1>&2
-          '';
-        };
-      });
+            shellHook = ''
+              ${qel.shellHook}
+            '';
+          };
+        });
 }

--- a/doc/arg.md
+++ b/doc/arg.md
@@ -1286,7 +1286,7 @@ _qel_completion() {
   # call command to get completions
   local output
   if [[ "${extension}" == 'js' ]]; then
-    output=$(COMP_LINE="${COMP_LINE}" COMP_POINT="${COMP_POINT}" qjs.sh --unhandled-rejection ${cmd})
+    output=$(COMP_LINE="${COMP_LINE}" COMP_POINT="${COMP_POINT}" qjs.sh ${cmd})
   else
     output=$(COMP_LINE="${COMP_LINE}" COMP_POINT="${COMP_POINT}" ${cmd})
   fi
@@ -1332,7 +1332,7 @@ _qel_completion() {
   # call command to get completions
   local output
   if [[ "${extension}" == 'js' ]]; then
-    output=$(QEL_COMPLETION_SHELL=zsh COMP_LINE="${cmd_line}" COMP_POINT="${CURSOR}" qjs.sh --unhandled-rejection ${cmd})
+    output=$(QEL_COMPLETION_SHELL=zsh COMP_LINE="${cmd_line}" COMP_POINT="${CURSOR}" qjs.sh ${cmd})
   else
     output=$(QEL_COMPLETION_SHELL=zsh COMP_LINE="${cmd_line}" COMP_POINT="${CURSOR}" ${cmd})
   fi

--- a/doc/arg.md
+++ b/doc/arg.md
@@ -53,6 +53,7 @@ Command-line parser based on https://github.com/vercel/arg/tree/5.0.0
   - [Completion functions](#completion-functions)
     - [bash](#bash)
     - [zsh](#zsh)
+  - [Generate completion](#generate-completion)
 - [Faq](#faq)
   - [Does it support sub commands ?](#does-it-support-sub-commands-)
   - [Does it support completion](#does-it-support-completion)
@@ -1364,6 +1365,56 @@ Scripts can then be registered like this
 ```shell
 # Register the completion function for your command
 compdef _qel_completion my-script
+```
+
+### Generate completion
+
+Both completions functions and completion registration can be generated using `qel-completion.sh` script _nix dev shell_
+
+```
+qel-completion.sh --help
+```
+
+```shell
+Output shell completion to stdout
+
+Usage: qel-completion.sh [ARG] ...
+
+  -c, --config FILE                 : path to the 'qel.config.json' file (by default, use the
+                                      'qel.config.json' file at the root of the git repository)
+  -s, --shell NAME                  : shell to generate completion for (default: bash)
+                                        - it can be one of [bash, zsh]
+                                        - it can be passed as 'QEL_COMPLETION_SHELL' environment variable
+  --function-name NAME              : name of the shell function used for completion (default:
+                                      _qel_completion)
+                                        - it can be passed as 'QEL_COMPLETION_FUNCTION_NAME' environment variable
+  --(no-)randomize-function-name    : if set, a randomize value will be added at the end of the function name
+                                      (set by default)
+                                        - it can be passed as 'QEL_COMPLETION_RANDOMIZE_FUNCTION_NAME' environment
+                                          variable
+  --(no-)function                   : if set, output completion function (set by default)
+                                        - it can be passed as 'QEL_COMPLETION_ENABLE_FUNCTION' environment
+                                          variable
+  --(no-)setup                      : if set, output completion setup for each script (set by default)
+                                        - it can be passed as 'QEL_COMPLETION_ENABLE_SETUP' environment variable
+  --(no-)release                    : if set, output completion setup for "release" (ie: compiled) scripts
+                                      (ignored if --setup is not set (set by default)
+                                        - it can be passed as 'QEL_COMPLETION_SETUP_FOR_RELEASE' environment
+                                          variable
+  --(no-)dev                        : if set, output completion setup for "dev" (ie: .js) scripts (ignored if
+                                      --setup is not set
+                                        - it can be passed as 'QEL_COMPLETION_SETUP_FOR_DEV' environment variable
+  -h, --help                        : print help
+
+EXAMPLES
+
+$ qel-completion.sh -s zsh
+
+$ qel-completion.sh -s zsh --dev
+
+$ qel-completion.sh --function-name _my_completion_function
+
+$ qel-completion.sh --no-setup
 ```
 
 ## Faq

--- a/flake.lock
+++ b/flake.lock
@@ -18,24 +18,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1724479785,
@@ -86,48 +68,32 @@
     },
     "quickjs-static": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1724968871,
-        "narHash": "sha256-oacUxfcNyjpCs25A1BnN/Cys9Ldax5rskxlZFjpKvco=",
+        "lastModified": 1747314335,
+        "narHash": "sha256-0APZ9XO+1Pq5z0X9enUZgBWeCbSUeVfV/qsirou7pB8=",
         "owner": "ctn-malone",
         "repo": "quickjs-cross-compiler",
-        "rev": "d8010afb61ef9c7d53c0bd26e65af83b83ce5e48",
+        "rev": "36bc7985737c6b3e9e4701e2d369dfa17ed96c0b",
         "type": "github"
       },
       "original": {
         "owner": "ctn-malone",
         "repo": "quickjs-cross-compiler",
-        "rev": "d8010afb61ef9c7d53c0bd26e65af83b83ce5e48",
+        "rev": "36bc7985737c6b3e9e4701e2d369dfa17ed96c0b",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "nixpkgs-gum": "nixpkgs-gum",
         "quickjs-static": "quickjs-static"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -2,117 +2,112 @@
   description = "QuickJS Extensions Library";
 
   inputs = {
-    nixpkgs = { url = "github:nixos/nixpkgs/nixos-unstable"; };
-
-    quickjs-static.url =
-      "github:ctn-malone/quickjs-cross-compiler?rev=d8010afb61ef9c7d53c0bd26e65af83b83ce5e48";
-    flake-utils.url = "github:numtide/flake-utils";
-    # pin gum to version 0.12
-    nixpkgs-gum.url =
-      "github:nixos/nixpkgs/5112417739f9b198047bedc352cebb41aa339e1d";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    quickjs-static.url = "github:ctn-malone/quickjs-cross-compiler?rev=36bc7985737c6b3e9e4701e2d369dfa17ed96c0b";
+    nixpkgs-gum.url = "github:nixos/nixpkgs/5112417739f9b198047bedc352cebb41aa339e1d";
   };
 
-  outputs = { self, nixpkgs, quickjs-static, flake-utils, nixpkgs-gum }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" "armv7l-linux" "aarch64-linux" ]
-    (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-        pkgs-gum = nixpkgs-gum.legacyPackages.${system};
+  outputs = { self, nixpkgs, quickjs-static, nixpkgs-gum, ... }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "armv7l-linux" ];
+      system = builtins.currentSystem or "x86_64-linux";
 
-        highlight = text: "\\x1b[1;38;5;212m${text}\\x1b[0m";
+      # Check if the current system is supported
+      assertSupported = builtins.elem system supportedSystems;
 
-        bootstrap = pkgs.writeShellApplication {
-          name = "qel-bootstrap.sh";
-          runtimeInputs = [ pkgs-gum.gum ];
-          text = ''
-            script_dir="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
-            bootstrap_dir="$(realpath "$script_dir/../bootstrap")"
-            QEL_TEMPLATES_ROOT_DIR="$bootstrap_dir/templates" \
-              QEL_EXT_DIR="$script_dir/ext" "$script_dir"/qjs.sh "$bootstrap_dir/bootstrap.js" "$@"
-          '';
-        };
-      in {
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [
+          (final: prev: {
+            quickjsStatic = quickjs-static.packages.${system}.quickjs-static;
+          })
+        ];
+      };
 
-        packages.qjs-ext-lib = pkgs.stdenv.mkDerivation {
-          name = "qjs-ext-lib";
+      pkgs-gum = import nixpkgs-gum { inherit system; };
 
-          src = ./.;
+      highlight = text: "\\x1b[1;38;5;212m${text}\\x1b[0m";
 
-          configurePhase = false;
-          buildPhase = false;
-          installPhase = ''
-            mkdir -p $out/bin/ext
-            cp -R $src/src/* $out/bin/ext
+      bootstrapScript = pkgs.writeShellScriptBin "qel-bootstrap.sh" ''
+        export PATH=${pkgs-gum.gum}/bin:$PATH
+        script_dir="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+        bootstrap_dir="$(realpath "$script_dir/../bootstrap")"
+        QEL_TEMPLATES_ROOT_DIR="$bootstrap_dir/templates" \
+          QEL_EXT_DIR="$script_dir/ext" "$script_dir"/qjs.sh "$bootstrap_dir/bootstrap.js" "$@"
+      '';
 
-            cp -R ${
-              quickjs-static.packages.${system}.quickjs-static
-            }/bin/* $out/bin
+      generateCompletionScript = pkgs.writeShellScriptBin "qel-completion.sh" ''
+        script_dir="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+        bootstrap_dir="$(realpath "$script_dir/../bootstrap")"
+        QEL_TEMPLATES_ROOT_DIR="$bootstrap_dir/templates" \
+          "$script_dir"/qjs.sh "$bootstrap_dir/generate-completion.js" "$@"
+      '';
 
-            # rewrite ext symlink in bootstrap
-            mkdir -p bootstrap
-            cp -R $src/bootstrap/* bootstrap
-            rm -f bootstrap/ext
-            ln -s ../bin/ext bootstrap/ext
-            mkdir -p $out/bootstrap
-            cp -R bootstrap $out
+      qjsExtLib = pkgs.stdenv.mkDerivation {
+        name = "qjs-ext-lib";
+        src = pkgs.lib.cleanSource ./.;
+        configurePhase = false;
+        buildPhase = false;
+        installPhase = ''
+          mkdir -p $out/bin/ext
+          cp -R $src/src/* $out/bin/ext
+          cp -R ${pkgs.quickjsStatic}/bin/* $out/bin
 
-            cp $src/shell/qel-*.sh $out/bin
-            cp -R ${bootstrap}/bin/qel-bootstrap.sh $out/bin
-          '';
-        };
+          # rewrite ext symlink in bootstrap
+          mkdir -p bootstrap
+          cp -R $src/bootstrap/* bootstrap
+          rm -f bootstrap/ext
+          ln -s ../bin/ext bootstrap/ext
+          mkdir -p $out/bootstrap
+          cp -R bootstrap $out
 
-        defaultPackage = self.packages.${system}.qjs-ext-lib;
+          cp $src/shell/qel-*.sh $out/bin
+          cp -R ${bootstrapScript}/bin/qel-bootstrap.sh $out/bin
+          cp -R ${generateCompletionScript}/bin/qel-completion.sh $out/bin
+        '';
+      };
+    in
+    if assertSupported then {
+      packages.${system} = {
+        default = qjsExtLib;
+        qjs-ext-lib = qjsExtLib;
+      };
 
-        apps = {
-          # interpreter
-          default = {
-            type = "app";
-            program = "${self.packages.${system}.qjs-ext-lib}/bin/qjs.sh";
-          };
-
-          qjs = self.apps.${system}.default;
-
-          # compiler
-          qjsc = {
-            type = "app";
-            program = "${self.packages.${system}.qjs-ext-lib}/bin/qjsc.sh";
-          };
-
-          # initialize a new repository
-          bootstrap = {
-            type = "app";
-            program =
-              "${self.packages.${system}.qjs-ext-lib}/bin/qel-bootstrap.sh";
-          };
+      apps.${system} = {
+        default = {
+          type = "app";
+          program = "${qjsExtLib}/bin/qjs.sh";
         };
 
-        # dev shell with extra runtime dependencies
-        devShell = pkgs.mkShell {
-          name = "qjs-ext-lib";
-
-          buildInputs = [
-            # to compress compiled binaries
-            pkgs.upx
-            pkgs.curl
-            # to build interactive CLIs
-            pkgs-gum.gum
-            self.packages.${system}.qjs-ext-lib
-          ];
-
-          shellHook = ''
-            echo -e "To compile a JS file, use ${
-              highlight "qjsc.sh -o <binary> <source>"
-            } (ex: ${highlight "qjsc.sh -o /tmp/example example.js"})" 1>&2
-            echo -e "To run a JS file, use ${
-              highlight "qjs.sh <source>"
-            } (ex: ${highlight "qjs.sh example.js"})" 1>&2
-            echo -e "To create a symlink to the lib directory (and improve completion/typing in your IDE), use ${
-              highlight "qel-symlink.sh"
-            }" 1>&2
-            echo -e "To bootstrap a new project, use ${
-              highlight "qel-bootstrap.sh"
-            }" 1>&2
-          '';
+        qjs = self.apps.${system}.default;
+        qjsc = {
+          type = "app";
+          program = "${qjsExtLib}/bin/qjsc.sh";
         };
-      });
+        bootstrap = {
+          type = "app";
+          program = "${qjsExtLib}/bin/qel-bootstrap.sh";
+        };
+      };
+
+      devShells.${system}.default = pkgs.mkShell {
+        name = "qjs-ext-lib-dev";
+        buildInputs = [ pkgs.upx pkgs.curl pkgs-gum.gum qjsExtLib ];
+        shellHook = ''
+          echo -e "To compile a JS file, use ${
+            highlight "qjsc.sh -o <binary> <source>"
+          }" 1>&2
+          echo -e "To run a JS file, use ${
+            highlight "qjs.sh <source>"
+          }" 1>&2
+          echo -e "To create a symlink to the lib directory, use ${
+            highlight "qel-symlink.sh"
+          }" 1>&2
+          echo -e "To bootstrap a new project, use ${
+            highlight "qel-bootstrap.sh"
+          }" 1>&2
+        '';
+      };
+    } else
+      throw "Unsupported system: ${system}. Supported systems: ${builtins.concatStringsSep ", " supportedSystems}";
 }

--- a/src/arg.js
+++ b/src/arg.js
@@ -527,6 +527,8 @@ const arg = (specs, options) => {
    * Print usage and exit with code 2
    *
    * @param {string} [errMessage] - error message to print before usage
+   *
+   * @return {never}
    */
   result.usage = (errMessage) => {
     if (errMessage) {
@@ -563,6 +565,8 @@ const arg = (specs, options) => {
 
   /**
    * Print help and exit with code 0
+   *
+   * @return {never}
    */
   result.help = () => {
     std.out.puts(`${result.getHelp()}\n`);

--- a/src/internal/arg.js
+++ b/src/internal/arg.js
@@ -1586,6 +1586,7 @@ export class PathArgValidator extends BaseStringArgValidator {
       if (fd < 0) {
         throw new Error(`could not create file - errCode: ${-fd}`);
       }
+      os.close(fd);
     });
     return this;
   }

--- a/src/os.js
+++ b/src/os.js
@@ -705,11 +705,11 @@ export const mkstemp =
  *
  * @param {string} template - template used to generate a unique temporary dirname.
  *                            It must end with XXXXXX
- * @param {{errno: number}} [errorObj] - if defined, set its "errno" property to the error code or to 0 if no error occured
+ * @param {{errno?: number}} [errorObj] - if defined, set its "errno" property to the error code or to 0 if no error occured
  *
  * @returns {string | null} temporary dirname or null on error
  */
 export const mkdtemp =
-  /** @type {(template: string | null, errorObj?: {errno: number}) => string} */ (
+  /** @type {(template: string | null, errorObj?: {errno?: number}) => string} */ (
     os.mkdtemp
   );

--- a/src/version.js
+++ b/src/version.js
@@ -10,7 +10,7 @@
   An exception will be thrown in case a non semver version is passed as argument
  */
 
-const VERSION = '0.14.2';
+const VERSION = '0.15.0';
 
 /**
  * Check whether or not a version is in semver format

--- a/test/tests/test.gum.js
+++ b/test/tests/test.gum.js
@@ -868,6 +868,7 @@ export default () => {
             GUM_SPIN_ALIGN: gum.Align.LEFT,
           });
         },
+        dryRunVersion: '0.16.0',
       },
     });
   });
@@ -909,6 +910,7 @@ export default () => {
             GUM_SPIN_ALIGN: 'align-var',
           });
         },
+        dryRunVersion: '0.16.0',
       },
     });
   });


### PR DESCRIPTION
## [0.15.0]
* chore: update `flake.nix` template
* chore: add a _shebang_ to script templates
* chore: indicate whether or not a script supports completion in `qel.config.json`
* chore: update `quickjs-cross-compiler` version in `flake.nix`
* chore: add `qel-completion.sh` script to generate completion for both `bash` and `zsh`
* chore: setup shell completion when entering `nix develop` shell
* fix: fix `qel-upgrade.sh` script
* fix: close file handle after ensuring a file exists (`args.js`)
* fix: escape `:` when generating completions for `zsh`
* refactor: make `errno` optional in `errorObj` (`std.js`, `os.js`)