### PR TITLE
chore: version 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.16.0]
+* feat: add support for [gum](https://github.com/charmbracelet/gum) version (`v0.17.0`) (`gum.js`)
+* refactor: use [gum](https://github.com/charmbracelet/gum) version (`v0.17.0`) in bootstrap
+
 ## [0.15.4]
 * refactor: improve typing (`process.js`, `curl.js`)
 * feat: add `getChildPids` function (`process.js`)

--- a/bootstrap/templates/nix/flake.nix
+++ b/bootstrap/templates/nix/flake.nix
@@ -4,9 +4,8 @@
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     qjsExtLib.url = "github:ctn-malone/qjs-ext-lib";
-    # pin gum to version 0.12
-    nixpkgs-gum.url =
-      "github:nixos/nixpkgs/5112417739f9b198047bedc352cebb41aa339e1d";
+    # pin gum to version 0.17.0
+    nixpkgs-gum.url = "github:nixos/nixpkgs/554be6495561ff07b6c724047bdd7e0716aa7b46";
   };
 
   outputs = { self, nixpkgs, flake-utils, qjsExtLib, nixpkgs-gum }:

--- a/doc/gum.md
+++ b/doc/gum.md
@@ -109,6 +109,10 @@ Choose a single item from a list
   * opt.selected (*ListItem<T>|string*) : default item
   * opt.cursor (*string*) : prefix to show on item that corresponds to the cursor position (default = `"> "`) ($GUM_CHOOSE_CURSOR)
   * opt.height (*number*) : height of the list (default = `10`) ($GUM_CHOOSE_HEIGHT)
+  * opt.paddingLeft (*number*) : left padding (default = `0`) ($GUM_CHOOSE_PADDING_LEFT)
+  * opt.paddingRight (*number*) : right padding (default = `0`) ($GUM_CHOOSE_PADDING_RIGHT)
+  * opt.paddingTop (*number*) : top padding (default = `0`) ($GUM_CHOOSE_PADDING_TOP)
+  * opt.paddingBottom (*number*) : bottom padding (default = `0`) ($GUM_CHOOSE_PADDING_BOTTOM)
   * opt.custom (*CustomOptions*)
 
 **returns** *ListItem<T>|undefined*
@@ -152,6 +156,10 @@ Choose multiple items from a list (press `Space` to select / unselect an item, `
   * opt.cursorPrefix (*string*) : prefix to show on the cursor item (default = `"○ "`) ($GUM_CHOOSE_CURSOR_PREFIX)
   * opt.selectedPrefix (*string*) : prefix to show on selected items (default = `"◉ "`) ($GUM_CHOOSE_SELECTED_PREFIX)
   * opt.unselectedPrefix (*string*) : prefix to show on unselected items (default = `"○ "`) ($GUM_CHOOSE_UNSELECTED_PREFIX)
+  * opt.paddingLeft (*number*) : left padding (default = `0`) ($GUM_CHOOSE_PADDING_LEFT)
+  * opt.paddingRight (*number*) : right padding (default = `0`) ($GUM_CHOOSE_PADDING_RIGHT)
+  * opt.paddingTop (*number*) : top padding (default = `0`) ($GUM_CHOOSE_PADDING_TOP)
+  * opt.paddingBottom (*number*) : bottom padding (default = `0`) ($GUM_CHOOSE_PADDING_BOTTOM)
   * opt.custom (*CustomOptions*)
 
 **returns** *ListItem<T>[]|undefined*
@@ -197,6 +205,10 @@ Choose a single item by filtering a list
   * opt.fuzzy (*boolean*) : enable fuzzy search (default = `true`) ($GUM_FILTER_FUZZY)
   * opt.reverse (*boolean*) : display from the bottom of the screen (default = `false`) ($GUM_FILTER_REVERSE)
   * opt.sort (*boolean*) : sort the results (default = `true`) ($GUM_FILTER_SORT)
+  * opt.paddingLeft (*number*) : left padding (default = `0`) ($GUM_FILTER_PADDING_LEFT)
+  * opt.paddingRight (*number*) : right padding (default = `0`) ($GUM_FILTER_PADDING_RIGHT)
+  * opt.paddingTop (*number*) : top padding (default = `0`) ($GUM_FILTER_PADDING_TOP)
+  * opt.paddingBottom (*number*) : bottom padding (default = `0`) ($GUM_FILTER_PADDING_BOTTOM)
   * opt.custom (*CustomOptions*)
 
 **returns** *ListItem<T>|undefined*
@@ -240,6 +252,10 @@ Choose multiple items by filtering a list (press `Ctrl+Space` to select/unselect
   * opt.indicator (*string*) : character for selection (default = `"•"`) ($GUM_FILTER_INDICATOR)
   * opt.selectedPrefix (*string*) : character to indicate selected items (default = `" ◉ "`) ($GUM_FILTER_SELECTED_PREFIX)
   * opt.unselectedPrefix (*string*) : character to indicate selected items (default = `" ○ "`) ($GUM_FILTER_UNSELECTED_PREFIX)
+  * opt.paddingLeft (*number*) : left padding (default = `0`) ($GUM_FILTER_PADDING_LEFT)
+  * opt.paddingRight (*number*) : right padding (default = `0`) ($GUM_FILTER_PADDING_RIGHT)
+  * opt.paddingTop (*number*) : top padding (default = `0`) ($GUM_FILTER_PADDING_TOP)
+  * opt.paddingBottom (*number*) : bottom padding (default = `0`) ($GUM_FILTER_PADDING_BOTTOM)
   * opt.custom (*CustomOptions*)
 
 **returns** *ListItem<T>[]|undefined*
@@ -331,6 +347,10 @@ Render a list of rows as a table
 * opt (*object*) : options
   * opt.border (*Border*) : border style (default = `Border.ROUNDED`)
   * opt.widths (*number[]*) : column widths
+  * opt.paddingLeft (*number*) : left padding (default = `0`) ($GUM_TABLE_PADDING_LEFT)
+  * opt.paddingRight (*number*) : right padding (default = `0`) ($GUM_TABLE_PADDING_RIGHT)
+  * opt.paddingTop (*number*) : top padding (default = `0`) ($GUM_TABLE_PADDING_TOP)
+  * opt.paddingBottom (*number*) : bottom padding (default = `0`) ($GUM_TABLE_PADDING_BOTTOM)
   * opt.custom (*CustomOptions*)
 
 **returns** *string*
@@ -369,6 +389,10 @@ Choose a row from a table
 * opt (*object*) : options
   * opt.widths (*number[]*) : column widths
   * opt.height (*number*) : table height (default = `20`)
+  * opt.paddingLeft (*number*) : left padding (default = `0`) ($GUM_TABLE_PADDING_LEFT)
+  * opt.paddingRight (*number*) : right padding (default = `0`) ($GUM_TABLE_PADDING_RIGHT)
+  * opt.paddingTop (*number*) : top padding (default = `0`) ($GUM_TABLE_PADDING_TOP)
+  * opt.paddingBottom (*number*) : bottom padding (default = `0`) ($GUM_TABLE_PADDING_BOTTOM)
   * opt.custom (*CustomOptions*)
 
 **returns** *TableRow<T>|undefined*
@@ -404,6 +428,10 @@ Ask user to confirm an action
   * opt.affirmative (*string*) : affirmative answer (default = `"Yes"`)
   * opt.negative (*string*) : negative answer (default = `"No"`)
   * opt.default (*ConfirmAnswer*) : default confirmation action (default = `ConfirmAnswer.YES`)
+  * opt.paddingLeft (*number*) : left padding (default = `0`) ($GUM_CONFIRM_PADDING_LEFT)
+  * opt.paddingRight (*number*) : right padding (default = `0`) ($GUM_CONFIRM_PADDING_RIGHT)
+  * opt.paddingTop (*number*) : top padding (default = `0`) ($GUM_CONFIRM_PADDING_TOP)
+  * opt.paddingBottom (*number*) : bottom padding (default = `0`) ($GUM_CONFIRM_PADDING_BOTTOM)
   * opt.custom (*CustomOptions*)
 
 **returns** *boolean|undefined*
@@ -438,6 +466,10 @@ Pick a file from a folder
   * opt.all (*boolean*) : if true, show hidden and 'dot' files
   * opt.cursor (*string*) : the cursor character (default = `">"`) ($GUM_FILE_CURSOR)
   * opt.height (*number*) : maximum number of entries to display (default = `50`) ($GUM_FILE_HEIGHT)
+  * opt.paddingLeft (*number*) : left padding (default = `0`) ($GUM_FILE_PADDING_LEFT)
+  * opt.paddingRight (*number*) : right padding (default = `0`) ($GUM_FILE_PADDING_RIGHT)
+  * opt.paddingTop (*number*) : top padding (default = `0`) ($GUM_FILE_PADDING_TOP)
+  * opt.paddingBottom (*number*) : bottom padding (default = `0`) ($GUM_FILE_PADDING_BOTTOM)
   * opt.custom (*CustomOptions*)
 
 **returns** *string|undefined*
@@ -470,6 +502,10 @@ Pick a directory from a folder
   * opt.all (*boolean*) : if true, show hidden and 'dot' files
   * opt.cursor (*string*) : the cursor character (default = `">"`) ($GUM_FILE_CURSOR)
   * opt.height (*number*) : maximum number of entries to display (default = `50`) ($GUM_FILE_HEIGHT)
+  * opt.paddingLeft (*number*) : left padding (default = `0`) ($GUM_FILE_PADDING_LEFT)
+  * opt.paddingRight (*number*) : right padding (default = `0`) ($GUM_FILE_PADDING_RIGHT)
+  * opt.paddingTop (*number*) : top padding (default = `0`) ($GUM_FILE_PADDING_TOP)
+  * opt.paddingBottom (*number*) : bottom padding (default = `0`) ($GUM_FILE_PADDING_BOTTOM)
   * opt.custom (*CustomOptions*)
 
 **returns** *string|undefined*
@@ -502,6 +538,10 @@ Display a spinner while a promise is resolving
   * opt.title (*string*) : title value (default = `"Loading..."`) ($GUM_SPIN_TITLE)
   * opt.spinner (*string*) : spinner value (default = `Spinner.DOT`) ($GUM_SPIN_SPINNER)
   * opt.align (*string*) : alignment of spinner with regard to the title (default = `Align.LEFT`) ($GUM_SPIN_ALIGN)
+  * opt.paddingLeft (*number*) : left padding (default = `0`) ($GUM_SPIN_PADDING_LEFT)
+  * opt.paddingRight (*number*) : right padding (default = `0`) ($GUM_SPIN_PADDING_RIGHT)
+  * opt.paddingTop (*number*) : top padding (default = `0`) ($GUM_SPIN_PADDING_TOP)
+  * opt.paddingBottom (*number*) : bottom padding (default = `0`) ($GUM_SPIN_PADDING_BOTTOM)
   * opt.custom (*CustomOptions*)
 
 **returns** *Promise<boolean>* whether or not spinner was cancelled (ie: using Ctrl+C)
@@ -540,6 +580,10 @@ Prompt for some input
   * opt.password (*boolean*) : mask input characters (default = `false`)
   * opt.charLimit (*number*) : maximum value length (default = `400, 0 for no limit`)
   * opt.width (*number*) : input width (default = `40, 0 for terminal width`) ($GUM_INPUT_WIDTH)
+  * opt.paddingLeft (*number*) : left padding (default = `0`) ($GUM_INPUT_PADDING_LEFT)
+  * opt.paddingRight (*number*) : right padding (default = `0`) ($GUM_INPUT_PADDING_RIGHT)
+  * opt.paddingTop (*number*) : top padding (default = `0`) ($GUM_INPUT_PADDING_TOP)
+  * opt.paddingBottom (*number*) : bottom padding (default = `0`) ($GUM_INPUT_PADDING_BOTTOM)
   * opt.custom (*CustomOptions*)
 
 **returns** *string|undefined*
@@ -585,6 +629,10 @@ Prompt for long-form text (press `Ctrl+D` or `Esc` to confirm)
   * opt.width (*number*) : input width (default = `50, 0 for no limit`) ($GUM_WRITE_WIDTH)
   * opt.height (*number*) : input height (default = `10`) ($GUM_WRITE_HEIGHT)
   * opt.showLineNumbers (*boolean*) : show line numbers (default = `false`) ($GUM_WRITE_SHOW_LINE_NUMBERS)
+  * opt.paddingLeft (*number*) : left padding (default = `0`) ($GUM_WRITE_PADDING_LEFT)
+  * opt.paddingRight (*number*) : right padding (default = `0`) ($GUM_WRITE_PADDING_RIGHT)
+  * opt.paddingTop (*number*) : top padding (default = `0`) ($GUM_WRITE_PADDING_TOP)
+  * opt.paddingBottom (*number*) : bottom padding (default = `0`) ($GUM_WRITE_PADDING_BOTTOM)
   * opt.custom (*CustomOptions*)
 
 **returns** *string|undefined*
@@ -712,6 +760,10 @@ Scroll through content
 * opt (*object*) : options
   * opt.showLineNumbers (*boolean*) : show line numbers (default = `true`)
   * opt.softWrap (*boolean*) : soft wrap lines (default = `false`)
+  * opt.paddingLeft (*number*) : left padding (default = `0`) ($GUM_PAGER_PADDING_LEFT)
+  * opt.paddingRight (*number*) : right padding (default = `0`) ($GUM_PAGER_PADDING_RIGHT)
+  * opt.paddingTop (*number*) : top padding (default = `0`) ($GUM_PAGER_PADDING_TOP)
+  * opt.paddingBottom (*number*) : bottom padding (default = `0`) ($GUM_PAGER_PADDING_BOTTOM)
   * opt.custom (*CustomOptions*)
 
 **returns** *string*

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724479785,
-        "narHash": "sha256-pP3Azj5d6M5nmG68Fu4JqZmdGt4S4vqI5f8te+E/FTw=",
+        "lastModified": 1758427187,
+        "narHash": "sha256-pHpxZ/IyCwoTQPtFIAG2QaxuSm8jWzrzBGjwQZIttJc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
+        "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
         "type": "github"
       },
       "original": {
@@ -36,17 +36,17 @@
     },
     "nixpkgs-gum": {
       "locked": {
-        "lastModified": 1701122557,
-        "narHash": "sha256-c6HQV88IWEIgSSerYIjSRMibSjqSTy7oDKqXbf3kVvo=",
+        "lastModified": 1758427187,
+        "narHash": "sha256-pHpxZ/IyCwoTQPtFIAG2QaxuSm8jWzrzBGjwQZIttJc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5112417739f9b198047bedc352cebb41aa339e1d",
+        "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5112417739f9b198047bedc352cebb41aa339e1d",
+        "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,8 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     quickjs-static.url = "github:ctn-malone/quickjs-cross-compiler?rev=1066cf6aad9f10edfafc4e0302d7d951a327f437";
-    nixpkgs-gum.url = "github:nixos/nixpkgs/5112417739f9b198047bedc352cebb41aa339e1d";
+    # pin gum to version 0.17.0
+    nixpkgs-gum.url = "github:nixos/nixpkgs/554be6495561ff07b6c724047bdd7e0716aa7b46";
   };
 
   outputs = { self, nixpkgs, quickjs-static, nixpkgs-gum, ... }:

--- a/src/gum.js
+++ b/src/gum.js
@@ -300,6 +300,10 @@ const findItems = (list, values) => {
 
 const CHOOSE_DEFAULT_HEIGHT = 10;
 const CHOOSE_DEFAULT_CURSOR = '> ';
+const CHOOSE_DEFAULT_PADDING_LEFT = 0;
+const CHOOSE_DEFAULT_PADDING_RIGHT = 0;
+const CHOOSE_DEFAULT_PADDING_TOP = 0;
+const CHOOSE_DEFAULT_PADDING_BOTTOM = 0;
 
 /**
  * Choose a single item from a list
@@ -313,6 +317,10 @@ const CHOOSE_DEFAULT_CURSOR = '> ';
  * @param {ListItem<T>|string} [opt.selected] - default item
  * @param {string} [opt.cursor="> "] - prefix to show on item that corresponds to the cursor position (default = "> ") ($GUM_CHOOSE_CURSOR)
  * @param {number} [opt.height=10] - height of the list (default = 10) ($GUM_CHOOSE_HEIGHT)
+ * @param {number} [opt.paddingLeft=0] - left padding (default = 0) ($GUM_CHOOSE_PADDING_LEFT) (>= v0.17.0)
+ * @param {number} [opt.paddingRight=0] - right padding (default = 0) ($GUM_CHOOSE_PADDING_RIGHT) (>= v0.17.0)
+ * @param {number} [opt.paddingTop=0] - top padding (default = 0) ($GUM_CHOOSE_PADDING_TOP) (>= v0.17.0)
+ * @param {number} [opt.paddingBottom=0] - bottom padding (default = 0) ($GUM_CHOOSE_PADDING_BOTTOM) (>= v0.17.0)
  * @param {CustomOptions} [opt.custom]
  *
  * @returns {ListItem<T>|undefined}
@@ -320,6 +328,13 @@ const CHOOSE_DEFAULT_CURSOR = '> ';
 export const chooseItemFromList = (list, opt) => {
   opt = opt || {};
   const items = buildItems(list);
+
+  /*
+    We retrieve environment first because merging padding
+    values relies on those environment variables as fallback
+   */
+  const env = getEnv(opt.custom?.env, ['PADDING']);
+
   const cmdline = ['gum', 'choose', '--limit', '1'];
   if (opt.header) {
     cmdline.push('--header', opt.header);
@@ -338,8 +353,25 @@ export const chooseItemFromList = (list, opt) => {
     cmdline.push('--height', opt.height.toString());
   }
 
-  addCustomArguments(cmdline, opt.custom?.args, ['limit', 'no-limit']);
-  const env = getEnv(opt.custom?.env);
+  if (versionGte('0.17.0', opt?.custom?.dryRunVersion)) {
+    cmdline.push(
+      '--padding',
+      mergePaddingValues(
+        env,
+        opt.paddingTop,
+        opt.paddingRight,
+        opt.paddingBottom,
+        opt.paddingLeft,
+        'GUM_CHOOSE_'
+      )
+    );
+  }
+
+  addCustomArguments(cmdline, opt.custom?.args, [
+    'limit',
+    'no-limit',
+    '--padding',
+  ]);
 
   if (opt.custom?.dryRunCb) {
     opt.custom.dryRunCb(cmdline, env);
@@ -379,6 +411,10 @@ const CHOOSE_DEFAULT_ORDERED = 'no';
  * @param {string} [opt.cursorPrefix="○ "] - prefix to show on the cursor item (default = "○ ") ($GUM_CHOOSE_CURSOR_PREFIX)
  * @param {string} [opt.selectedPrefix="◉ "] - prefix to show on selected items (default = "◉ ") ($GUM_CHOOSE_SELECTED_PREFIX)
  * @param {string} [opt.unselectedPrefix="○ "] - prefix to show on unselected items (default = "○ ") ($GUM_CHOOSE_UNSELECTED_PREFIX)
+ * @param {number} [opt.paddingLeft=0] - left padding (default = 0) ($GUM_CHOOSE_PADDING_LEFT) (>= v0.17.0)
+ * @param {number} [opt.paddingRight=0] - right padding (default = 0) ($GUM_CHOOSE_PADDING_RIGHT) (>= v0.17.0)
+ * @param {number} [opt.paddingTop=0] - top padding (default = 0) ($GUM_CHOOSE_PADDING_TOP) (>= v0.17.0)
+ * @param {number} [opt.paddingBottom=0] - bottom padding (default = 0) ($GUM_CHOOSE_PADDING_BOTTOM) (>= v0.17.0)
  * @param {CustomOptions} [opt.custom]
  *
  * @returns {ListItem<T>[]|undefined}
@@ -386,6 +422,13 @@ const CHOOSE_DEFAULT_ORDERED = 'no';
 export const chooseItemsFromList = (list, opt) => {
   opt = opt || {};
   const items = buildItems(list);
+
+  /*
+    We retrieve environment first because merging padding
+    values relies on those environment variables as fallback
+   */
+  const env = getEnv(opt.custom?.env, ['PADDING']);
+
   const cmdline = ['gum', 'choose'];
   if (opt.header) {
     cmdline.push('--header', opt.header);
@@ -430,8 +473,25 @@ export const chooseItemsFromList = (list, opt) => {
     cmdline.push(`--unselected-prefix=${opt.unselectedPrefix}`);
   }
 
-  addCustomArguments(cmdline, opt.custom?.args, ['limit', 'no-limit']);
-  const env = getEnv(opt.custom?.env);
+  if (versionGte('0.17.0', opt?.custom?.dryRunVersion)) {
+    cmdline.push(
+      '--padding',
+      mergePaddingValues(
+        env,
+        opt.paddingTop,
+        opt.paddingRight,
+        opt.paddingBottom,
+        opt.paddingLeft,
+        'GUM_CHOOSE_'
+      )
+    );
+  }
+
+  addCustomArguments(cmdline, opt.custom?.args, [
+    'limit',
+    'no-limit',
+    '--padding',
+  ]);
 
   if (opt.custom?.dryRunCb) {
     opt.custom.dryRunCb(cmdline, env);
@@ -457,6 +517,10 @@ const FILTER_DEFAULT_PLACEHOLDER = 'Filter...';
 const FILTER_DEFAULT_FUZZY = 'yes';
 const FILTER_DEFAULT_SORT = 'yes';
 const FILTER_DEFAULT_REVERSE = 'no';
+const FILTER_DEFAULT_PADDING_LEFT = 0;
+const FILTER_DEFAULT_PADDING_RIGHT = 0;
+const FILTER_DEFAULT_PADDING_TOP = 0;
+const FILTER_DEFAULT_PADDING_BOTTOM = 0;
 
 /**
  * Choose a single item by filtering a list
@@ -475,6 +539,10 @@ const FILTER_DEFAULT_REVERSE = 'no';
  * @param {boolean} [opt.fuzzy=true] - enable fuzzy search (default = true) ($GUM_FILTER_FUZZY)
  * @param {boolean} [opt.reverse=false] - display from the bottom of the screen (default = false) ($GUM_FILTER_REVERSE)
  * @param {boolean} [opt.sort=true] - sort the results (default = true) ($GUM_FILTER_SORT)
+ * @param {number} [opt.paddingLeft=0] - left padding (default = 0) ($GUM_FILTER_PADDING_LEFT) (>= v0.17.0)
+ * @param {number} [opt.paddingRight=0] - right padding (default = 0) ($GUM_FILTER_PADDING_RIGHT) (>= v0.17.0)
+ * @param {number} [opt.paddingTop=0] - top padding (default = 0) ($GUM_FILTER_PADDING_TOP) (>= v0.17.0)
+ * @param {number} [opt.paddingBottom=0] - bottom padding (default = 0) ($GUM_FILTER_PADDING_BOTTOM) (>= v0.17.0)
  * @param {CustomOptions} [opt.custom]
  *
  * @returns {ListItem<T>|undefined}
@@ -482,6 +550,13 @@ const FILTER_DEFAULT_REVERSE = 'no';
 export const filterItemFromList = (list, opt) => {
   opt = opt || {};
   const items = buildItems(list);
+
+  /*
+    We retrieve environment first because merging padding
+    values relies on those environment variables as fallback
+   */
+  const env = getEnv(opt.custom?.env, ['PADDING']);
+
   const cmdline = ['gum', 'filter', '--limit', '1'];
   if (opt.header) {
     cmdline.push('--header', opt.header);
@@ -511,8 +586,25 @@ export const filterItemFromList = (list, opt) => {
     cmdline.push(`--reverse=${opt.reverse ? 'yes' : 'no'}`);
   }
 
-  addCustomArguments(cmdline, opt.custom?.args, ['limit', 'no-limit']);
-  const env = getEnv(opt.custom?.env);
+  if (versionGte('0.17.0', opt?.custom?.dryRunVersion)) {
+    cmdline.push(
+      '--padding',
+      mergePaddingValues(
+        env,
+        opt.paddingTop,
+        opt.paddingRight,
+        opt.paddingBottom,
+        opt.paddingLeft,
+        'GUM_FILTER_'
+      )
+    );
+  }
+
+  addCustomArguments(cmdline, opt.custom?.args, [
+    'limit',
+    'no-limit',
+    '--padding',
+  ]);
 
   if (opt.custom?.dryRunCb) {
     opt.custom.dryRunCb(cmdline, env);
@@ -555,6 +647,10 @@ const FILTER_DEFAULT_UNSELECTED_PREFIX = ' ○ ';
  * @param {string} [opt.indicator="•"] - character for selection (default = "•") ($GUM_FILTER_INDICATOR)
  * @param {string} [opt.selectedPrefix=" ◉ "] - character to indicate selected items (default = " ◉ ") ($GUM_FILTER_SELECTED_PREFIX)
  * @param {string} [opt.unselectedPrefix=" ○ "] - character to indicate selected items (default = " ○ ") ($GUM_FILTER_UNSELECTED_PREFIX)
+ * @param {number} [opt.paddingLeft=0] - left padding (default = 0) ($GUM_FILTER_PADDING_LEFT) (>= v0.17.0)
+ * @param {number} [opt.paddingRight=0] - right padding (default = 0) ($GUM_FILTER_PADDING_RIGHT) (>= v0.17.0)
+ * @param {number} [opt.paddingTop=0] - top padding (default = 0) ($GUM_FILTER_PADDING_TOP) (>= v0.17.0)
+ * @param {number} [opt.paddingBottom=0] - bottom padding (default = 0) ($GUM_FILTER_PADDING_BOTTOM) (>= v0.17.0)
  * @param {CustomOptions} [opt.custom]
  *
  * @returns {ListItem<T>[]|undefined}
@@ -562,6 +658,13 @@ const FILTER_DEFAULT_UNSELECTED_PREFIX = ' ○ ';
 export const filterItemsFromList = (list, opt) => {
   opt = opt || {};
   const items = buildItems(list);
+
+  /*
+    We retrieve environment first because merging padding
+    values relies on those environment variables as fallback
+   */
+  const env = getEnv(opt.custom?.env, ['PADDING']);
+
   const cmdline = ['gum', 'filter'];
   if (opt.header) {
     cmdline.push('--header', opt.header);
@@ -605,8 +708,25 @@ export const filterItemsFromList = (list, opt) => {
     cmdline.push('--unselected-prefix', opt.unselectedPrefix);
   }
 
-  addCustomArguments(cmdline, opt.custom?.args, ['limit', 'no-limit']);
-  const env = getEnv(opt.custom?.env);
+  if (versionGte('0.17.0', opt?.custom?.dryRunVersion)) {
+    cmdline.push(
+      '--padding',
+      mergePaddingValues(
+        env,
+        opt.paddingTop,
+        opt.paddingRight,
+        opt.paddingBottom,
+        opt.paddingLeft,
+        'GUM_FILTER_'
+      )
+    );
+  }
+
+  addCustomArguments(cmdline, opt.custom?.args, [
+    'limit',
+    'no-limit',
+    '--padding',
+  ]);
 
   if (opt.custom?.dryRunCb) {
     opt.custom.dryRunCb(cmdline, env);
@@ -651,13 +771,16 @@ const STYLE_DEFAULT_FAINT = 'no';
  * @param {number|string} [right] - value for right margin
  * @param {number|string} [bottom] - value for top margin
  * @param {number|string} [left] - value for right margin
+ * @param {string} [prefix=""] - variable prefix
  *
  * @return {string}
  */
-const mergeMarginValues = (env, top, right, bottom, left) => {
-  return `${top ?? env['MARGIN_TOP']} ${right ?? env['MARGIN_RIGHT']} ${
-    bottom ?? env['MARGIN_BOTTOM']
-  } ${left ?? env['MARGIN_LEFT']}`;
+const mergeMarginValues = (env, top, right, bottom, left, prefix = '') => {
+  return `${top ?? env[`${prefix}MARGIN_TOP`]} ${
+    right ?? env[`${prefix}MARGIN_RIGHT`]
+  } ${bottom ?? env[`${prefix}MARGIN_BOTTOM`]} ${
+    left ?? env[`${prefix}MARGIN_LEFT`]
+  }`;
 };
 
 /**
@@ -668,13 +791,16 @@ const mergeMarginValues = (env, top, right, bottom, left) => {
  * @param {number|string} [right] - value for right padding
  * @param {number|string} [bottom] - value for top padding
  * @param {number|string} [left] - value for right padding
+ * @param {string} [prefix=""] - variable prefix
  *
  * @return {string}
  */
-const mergePaddingValues = (env, top, right, bottom, left) => {
-  return `${top ?? env['PADDING_TOP']} ${right ?? env['PADDING_RIGHT']} ${
-    bottom ?? env['PADDING_BOTTOM']
-  } ${left ?? env['PADDING_LEFT']}`;
+const mergePaddingValues = (env, top, right, bottom, left, prefix = '') => {
+  return `${top ?? env[`${prefix}PADDING_TOP`]} ${
+    right ?? env[`${prefix}PADDING_RIGHT`]
+  } ${bottom ?? env[`${prefix}PADDING_BOTTOM`]} ${
+    left ?? env[`${prefix}PADDING_LEFT`]
+  }`;
 };
 
 /**
@@ -890,6 +1016,10 @@ const findTableRow = (rows, key) => {
 
 const TABLE_DEFAULT_BORDER = Border.ROUNDED;
 const TABLE_DEFAULT_HEIGHT = 20;
+const TABLE_DEFAULT_PADDING_LEFT = 0;
+const TABLE_DEFAULT_PADDING_RIGHT = 0;
+const TABLE_DEFAULT_PADDING_TOP = 0;
+const TABLE_DEFAULT_PADDING_BOTTOM = 0;
 
 /**
  * Render a list of rows as a table
@@ -902,6 +1032,10 @@ const TABLE_DEFAULT_HEIGHT = 20;
  * @param {object} [opt] - options
  * @param {Border} [opt.border="rounded"] - border style (default = Border.ROUNDED)
  * @param {number[]} [opt.widths] - column widths
+ * @param {number} [opt.paddingLeft=0] - left padding (default = 0) ($GUM_TABLE_PADDING_LEFT) (>= v0.17.0)
+ * @param {number} [opt.paddingRight=0] - right padding (default = 0) ($GUM_TABLE_PADDING_RIGHT) (>= v0.17.0)
+ * @param {number} [opt.paddingTop=0] - top padding (default = 0) ($GUM_TABLE_PADDING_TOP) (>= v0.17.0)
+ * @param {number} [opt.paddingBottom=0] - bottom padding (default = 0) ($GUM_TABLE_PADDING_BOTTOM) (>= v0.17.0)
  * @param {CustomOptions} [opt.custom]
  *
  * @returns {string}
@@ -909,6 +1043,13 @@ const TABLE_DEFAULT_HEIGHT = 20;
 export const renderTable = (columns, rows, opt) => {
   opt = opt || {};
   const extendedRows = buildTableRows(rows);
+
+  /*
+    We retrieve environment first because merging padding
+    values relies on those environment variables as fallback
+   */
+  const env = getEnv(opt.custom?.env, ['PADDING']);
+
   const cmdline = [
     'gum',
     'table',
@@ -927,13 +1068,27 @@ export const renderTable = (columns, rows, opt) => {
     cmdline.push('--widths', opt.widths.join(','));
   }
 
+  if (versionGte('0.17.0', opt?.custom?.dryRunVersion)) {
+    cmdline.push(
+      '--padding',
+      mergePaddingValues(
+        env,
+        opt.paddingTop,
+        opt.paddingRight,
+        opt.paddingBottom,
+        opt.paddingLeft,
+        'GUM_TABLE_'
+      )
+    );
+  }
+
   addCustomArguments(cmdline, opt.custom?.args, [
     'separator',
     's',
     'file',
     'f',
+    '--padding',
   ]);
-  const env = getEnv(opt.custom?.env);
 
   if (opt.custom?.dryRunCb) {
     opt.custom.dryRunCb(cmdline, env);
@@ -962,6 +1117,10 @@ export const renderTable = (columns, rows, opt) => {
  * @param {object} [opt] - options
  * @param {number[]} [opt.widths] - column widths
  * @param {number} [opt.height=20] - table height (default = 20)
+ * @param {number} [opt.paddingLeft=0] - left padding (default = 0) ($GUM_TABLE_PADDING_LEFT) (>= v0.17.0)
+ * @param {number} [opt.paddingRight=0] - right padding (default = 0) ($GUM_TABLE_PADDING_RIGHT) (>= v0.17.0)
+ * @param {number} [opt.paddingTop=0] - top padding (default = 0) ($GUM_TABLE_PADDING_TOP) (>= v0.17.0)
+ * @param {number} [opt.paddingBottom=0] - bottom padding (default = 0) ($GUM_TABLE_PADDING_BOTTOM) (>= v0.17.0)
  * @param {CustomOptions} [opt.custom]
  *
  * @returns {TableRow<T>|undefined}
@@ -969,6 +1128,13 @@ export const renderTable = (columns, rows, opt) => {
 export const chooseRowFromTable = (columns, rows, opt) => {
   opt = opt || {};
   const extendedRows = buildTableRows(rows);
+
+  /*
+    We retrieve environment first because merging padding
+    values relies on those environment variables as fallback
+   */
+  const env = getEnv(opt.custom?.env, ['PADDING']);
+
   const widths = columns.map((column) => column.length);
   // build input and update column widths
   const input = extendedRows
@@ -997,6 +1163,20 @@ export const chooseRowFromTable = (columns, rows, opt) => {
     cmdline.push('--widths', widths.join(','));
   }
 
+  if (versionGte('0.17.0', opt?.custom?.dryRunVersion)) {
+    cmdline.push(
+      '--padding',
+      mergePaddingValues(
+        env,
+        opt.paddingTop,
+        opt.paddingRight,
+        opt.paddingBottom,
+        opt.paddingLeft,
+        'GUM_TABLE_'
+      )
+    );
+  }
+
   addCustomArguments(cmdline, opt.custom?.args, [
     'separator',
     's',
@@ -1004,8 +1184,8 @@ export const chooseRowFromTable = (columns, rows, opt) => {
     'p',
     'file',
     'f',
+    '--padding',
   ]);
-  const env = getEnv(opt.custom?.env);
 
   if (opt.custom?.dryRunCb) {
     opt.custom.dryRunCb(cmdline, env);
@@ -1023,6 +1203,10 @@ export const chooseRowFromTable = (columns, rows, opt) => {
 };
 
 const CONFIRM_DEFAULT_PROMPT = 'Are you sure?';
+const CONFIRM_DEFAULT_PADDING_LEFT = 0;
+const CONFIRM_DEFAULT_PADDING_RIGHT = 0;
+const CONFIRM_DEFAULT_PADDING_TOP = 0;
+const CONFIRM_DEFAULT_PADDING_BOTTOM = 0;
 
 /**
  * @readonly
@@ -1043,12 +1227,23 @@ export const ConfirmAnswer = {
  * @param {string} [opt.affirmative="Yes"] - affirmative answer (default = "Yes")
  * @param {string} [opt.negative="No"] - negative answer (default = "No")
  * @param {ConfirmAnswer} [opt.default="yes"] - default confirmation action (default = ConfirmAnswer.YES)
+ * @param {number} [opt.paddingLeft=0] - left padding (default = 0) ($GUM_CONFIRM_PADDING_LEFT) (>= v0.17.0)
+ * @param {number} [opt.paddingRight=0] - right padding (default = 0) ($GUM_CONFIRM_PADDING_RIGHT) (>= v0.17.0)
+ * @param {number} [opt.paddingTop=0] - top padding (default = 0) ($GUM_CONFIRM_PADDING_TOP) (>= v0.17.0)
+ * @param {number} [opt.paddingBottom=0] - bottom padding (default = 0) ($GUM_CONFIRM_PADDING_BOTTOM) (>= v0.17.0)
  * @param {CustomOptions} [opt.custom]
  *
  * @returns {boolean|undefined}
  */
 export const confirm = (opt) => {
   opt = opt || {};
+
+  /*
+    We retrieve environment first because merging padding
+    values relies on those environment variables as fallback
+   */
+  const env = getEnv(opt.custom?.env, ['PADDING']);
+
   const cmdline = [
     'gum',
     'confirm',
@@ -1060,12 +1255,26 @@ export const confirm = (opt) => {
     opt.prompt || CONFIRM_DEFAULT_PROMPT,
   ];
 
+  if (versionGte('0.17.0', opt?.custom?.dryRunVersion)) {
+    cmdline.push(
+      '--padding',
+      mergePaddingValues(
+        env,
+        opt.paddingTop,
+        opt.paddingRight,
+        opt.paddingBottom,
+        opt.paddingLeft,
+        'GUM_CONFIRM_'
+      )
+    );
+  }
+
   addCustomArguments(cmdline, opt.custom?.args, [
     'default',
     'affirmative',
     'negative',
+    '--padding',
   ]);
-  const env = getEnv(opt.custom?.env);
 
   if (opt.custom?.dryRunCb) {
     opt.custom.dryRunCb(cmdline, env);
@@ -1090,6 +1299,10 @@ export const confirm = (opt) => {
 
 const FILE_DEFAULT_HEIGHT = 50;
 const FILE_DEFAULT_CURSOR = '>';
+const FILE_DEFAULT_PADDING_LEFT = 0;
+const FILE_DEFAULT_PADDING_RIGHT = 0;
+const FILE_DEFAULT_PADDING_TOP = 0;
+const FILE_DEFAULT_PADDING_BOTTOM = 0;
 
 /**
  * Pick a file from a folder
@@ -1101,12 +1314,23 @@ const FILE_DEFAULT_CURSOR = '>';
  * @param {boolean} [opt.all=false] - if true, show hidden and 'dot' files
  * @param {string} [opt.cursor=">"] - the cursor character (default = ">") ($GUM_FILE_CURSOR)
  * @param {number} [opt.height=50] - maximum number of entries to display (default=50) ($GUM_FILE_HEIGHT)
+ * @param {number} [opt.paddingLeft=0] - left padding (default = 0) ($GUM_FILE_PADDING_LEFT) (>= v0.17.0)
+ * @param {number} [opt.paddingRight=0] - right padding (default = 0) ($GUM_FILE_PADDING_RIGHT) (>= v0.17.0)
+ * @param {number} [opt.paddingTop=0] - top padding (default = 0) ($GUM_FILE_PADDING_TOP) (>= v0.17.0)
+ * @param {number} [opt.paddingBottom=0] - bottom padding (default = 0) ($GUM_FILE_PADDING_BOTTOM) (>= v0.17.0)
  * @param {CustomOptions} [opt.custom]
  *
  * @returns {string|undefined}
  */
 export const chooseFile = (opt) => {
   opt = opt || {};
+
+  /*
+    We retrieve environment first because merging padding
+    values relies on those environment variables as fallback
+   */
+  const env = getEnv(opt.custom?.env, ['PADDING']);
+
   const cmdline = ['gum', 'file', '--file=true', '--directory=false'];
   if (opt.cursor !== undefined) {
     cmdline.push(`--cursor=${opt.cursor}`);
@@ -1121,8 +1345,25 @@ export const chooseFile = (opt) => {
     cmdline.push(opt.path);
   }
 
-  addCustomArguments(cmdline, opt.custom?.args, ['file', 'directory']);
-  const env = getEnv(opt.custom?.env);
+  if (versionGte('0.17.0', opt?.custom?.dryRunVersion)) {
+    cmdline.push(
+      '--padding',
+      mergePaddingValues(
+        env,
+        opt.paddingTop,
+        opt.paddingRight,
+        opt.paddingBottom,
+        opt.paddingLeft,
+        'GUM_FILE_'
+      )
+    );
+  }
+
+  addCustomArguments(cmdline, opt.custom?.args, [
+    'file',
+    'directory',
+    '--padding',
+  ]);
 
   if (opt.custom?.dryRunCb) {
     opt.custom.dryRunCb(cmdline, env);
@@ -1149,12 +1390,23 @@ export const chooseFile = (opt) => {
  * @param {boolean} [opt.all=false] - if true, show hidden and 'dot' files
  * @param {string} [opt.cursor=">"] - the cursor character (default = ">") ($GUM_FILE_CURSOR)
  * @param {number} [opt.height=50] - maximum number of entries to display (default=50) ($GUM_FILE_HEIGHT)
+ * @param {number} [opt.paddingLeft=0] - left padding (default = 0) ($GUM_FILE_PADDING_LEFT) (>= v0.17.0)
+ * @param {number} [opt.paddingRight=0] - right padding (default = 0) ($GUM_FILE_PADDING_RIGHT) (>= v0.17.0)
+ * @param {number} [opt.paddingTop=0] - top padding (default = 0) ($GUM_FILE_PADDING_TOP) (>= v0.17.0)
+ * @param {number} [opt.paddingBottom=0] - bottom padding (default = 0) ($GUM_FILE_PADDING_BOTTOM) (>= v0.17.0)
  * @param {CustomOptions} [opt.custom]
  *
  * @returns {string|undefined}
  */
 export const chooseDirectory = (opt) => {
   opt = opt || {};
+
+  /*
+    We retrieve environment first because merging padding
+    values relies on those environment variables as fallback
+   */
+  const env = getEnv(opt.custom?.env, ['PADDING']);
+
   const cmdline = ['gum', 'file', '--file=false', '--directory=true'];
   if (opt.cursor !== undefined) {
     cmdline.push(`--cursor=${opt.cursor}`);
@@ -1169,8 +1421,25 @@ export const chooseDirectory = (opt) => {
     cmdline.push(opt.path);
   }
 
-  addCustomArguments(cmdline, opt.custom?.args, ['file', 'directory']);
-  const env = getEnv(opt.custom?.env);
+  if (versionGte('0.17.0', opt?.custom?.dryRunVersion)) {
+    cmdline.push(
+      '--padding',
+      mergePaddingValues(
+        env,
+        opt.paddingTop,
+        opt.paddingRight,
+        opt.paddingBottom,
+        opt.paddingLeft,
+        'GUM_FILE_'
+      )
+    );
+  }
+
+  addCustomArguments(cmdline, opt.custom?.args, [
+    'file',
+    'directory',
+    '--padding',
+  ]);
 
   if (opt.custom?.dryRunCb) {
     opt.custom.dryRunCb(cmdline, env);
@@ -1217,6 +1486,10 @@ export const SpinAlign = {
 const SPIN_DEFAULT_SPINNER = Spinner.DOT;
 const SPIN_DEFAULT_TITLE = 'Loading...';
 const SPIN_DEFAULT_ALIGN = SpinAlign.LEFT;
+const SPIN_DEFAULT_PADDING_LEFT = 0;
+const SPIN_DEFAULT_PADDING_RIGHT = 0;
+const SPIN_DEFAULT_PADDING_TOP = 0;
+const SPIN_DEFAULT_PADDING_BOTTOM = 0;
 
 /**
  * Display a spinner while a promise is resolving
@@ -1228,6 +1501,10 @@ const SPIN_DEFAULT_ALIGN = SpinAlign.LEFT;
  * @param {string} [opt.title="Loading..."] - title value (default = "Loading...") ($GUM_SPIN_TITLE)
  * @param {string} [opt.spinner="dot"] - spinner value (default = Spinner.DOT) ($GUM_SPIN_SPINNER)
  * @param {string} [opt.align="left"] - alignment of spinner with regard to the title (default = Align.LEFT) ($GUM_SPIN_ALIGN)
+ * @param {number} [opt.paddingLeft=0] - left padding (default = 0) ($GUM_SPIN_PADDING_LEFT) (>= v0.17.0)
+ * @param {number} [opt.paddingRight=0] - right padding (default = 0) ($GUM_SPIN_PADDING_RIGHT) (>= v0.17.0)
+ * @param {number} [opt.paddingTop=0] - top padding (default = 0) ($GUM_SPIN_PADDING_TOP) (>= v0.17.0)
+ * @param {number} [opt.paddingBottom=0] - bottom padding (default = 0) ($GUM_SPIN_PADDING_BOTTOM) (>= v0.17.0)
  * @param {CustomOptions} [opt.custom]
  *
  * @returns {Promise<boolean>} whether or not spinner was cancelled (ie: using Ctrl+C)
@@ -1237,6 +1514,13 @@ export const spin = async (promise, opt) => {
     return spinLegacy(promise, opt);
   }
   opt = opt || {};
+
+  /*
+    We retrieve environment first because merging padding
+    values relies on those environment variables as fallback
+   */
+  const env = getEnv(opt.custom?.env, ['PADDING']);
+
   const cmdline = ['gum', 'spin', '--show-stdout'];
   if (opt.title !== undefined) {
     cmdline.push('--title', opt.title);
@@ -1248,14 +1532,28 @@ export const spin = async (promise, opt) => {
     cmdline.push('--align', opt.align);
   }
 
+  if (versionGte('0.17.0', opt?.custom?.dryRunVersion)) {
+    cmdline.push(
+      '--padding',
+      mergePaddingValues(
+        env,
+        opt.paddingTop,
+        opt.paddingRight,
+        opt.paddingBottom,
+        opt.paddingLeft,
+        'GUM_SPIN_'
+      )
+    );
+  }
+
   addCustomArguments(cmdline, opt.custom?.args, [
     'show-output',
     'show-error',
     'show-stdout',
     'show-stderr',
     'timeout',
+    '--padding',
   ]);
-  const env = getEnv(opt.custom?.env);
 
   cmdline.push('--', 'tail', '-1');
 
@@ -1380,6 +1678,10 @@ const INPUT_DEFAULT_WIDTH = 0;
 const INPUT_DEFAULT_PLACEHOLDER = 'Type something...';
 const INPUT_DEFAULT_PROMPT = '> ';
 const INPUT_DEFAULT_CURSOR_MODE = CursorMode.BLINK;
+const INPUT_DEFAULT_PADDING_LEFT = 0;
+const INPUT_DEFAULT_PADDING_RIGHT = 0;
+const INPUT_DEFAULT_PADDING_TOP = 0;
+const INPUT_DEFAULT_PADDING_BOTTOM = 0;
 
 /**
  * Prompt for some input
@@ -1395,12 +1697,23 @@ const INPUT_DEFAULT_CURSOR_MODE = CursorMode.BLINK;
  * @param {boolean} [opt.password=false] - mask input characters (default = false)
  * @param {number} [opt.charLimit=400] - maximum value length (default = 400, 0 for no limit)
  * @param {number} [opt.width=0] - input width (0 = terminal width) ($GUM_INPUT_WIDTH)
+ * @param {number} [opt.paddingLeft=0] - left padding (default = 0) ($GUM_INPUT_PADDING_LEFT) (>= v0.17.0)
+ * @param {number} [opt.paddingRight=0] - right padding (default = 0) ($GUM_INPUT_PADDING_RIGHT) (>= v0.17.0)
+ * @param {number} [opt.paddingTop=0] - top padding (default = 0) ($GUM_INPUT_PADDING_TOP) (>= v0.17.0)
+ * @param {number} [opt.paddingBottom=0] - bottom padding (default = 0) ($GUM_INPUT_PADDING_BOTTOM) (>= v0.17.0)
  * @param {CustomOptions} [opt.custom]
  *
  * @returns {string|undefined}
  */
 export const input = (opt) => {
   opt = opt || {};
+
+  /*
+    We retrieve environment first because merging padding
+    values relies on those environment variables as fallback
+   */
+  const env = getEnv(opt.custom?.env, ['PADDING']);
+
   const cmdline = ['gum', 'input'];
   if (opt.header) {
     cmdline.push('--header', opt.header);
@@ -1428,8 +1741,21 @@ export const input = (opt) => {
     cmdline.push('--cursor.mode', opt.cursorMode);
   }
 
-  addCustomArguments(cmdline, opt.custom?.args);
-  const env = getEnv(opt.custom?.env);
+  if (versionGte('0.17.0', opt?.custom?.dryRunVersion)) {
+    cmdline.push(
+      '--padding',
+      mergePaddingValues(
+        env,
+        opt.paddingTop,
+        opt.paddingRight,
+        opt.paddingBottom,
+        opt.paddingLeft,
+        'GUM_INPUT_'
+      )
+    );
+  }
+
+  addCustomArguments(cmdline, opt.custom?.args, ['--padding']);
 
   if (opt.custom?.dryRunCb) {
     opt.custom.dryRunCb(cmdline, env);
@@ -1453,6 +1779,10 @@ const WRITE_DEFAULT_PROMPT = '┃ ';
 const WRITE_DEFAULT_CURSOR_MODE = CursorMode.BLINK;
 const WRITE_DEFAULT_CHAR_LIMIT = 400;
 const WRITE_DEFAULT_SHOW_LINE_NUMBERS = 'no';
+const WRITE_DEFAULT_PADDING_LEFT = 0;
+const WRITE_DEFAULT_PADDING_RIGHT = 0;
+const WRITE_DEFAULT_PADDING_TOP = 0;
+const WRITE_DEFAULT_PADDING_BOTTOM = 0;
 
 /**
  * Prompt for long-form text
@@ -1472,12 +1802,23 @@ const WRITE_DEFAULT_SHOW_LINE_NUMBERS = 'no';
  * @param {number} [opt.width=50] - input width (default = 50, 0 for no limit) ($GUM_WRITE_WIDTH)
  * @param {number} [opt.height=10] - input height (default = 10) ($GUM_WRITE_HEIGHT)
  * @param {boolean} [opt.showLineNumbers=false] - show line numbers (default = false) ($GUM_WRITE_SHOW_LINE_NUMBERS)
+ * @param {number} [opt.paddingLeft=0] - left padding (default = 0) ($GUM_WRITE_PADDING_LEFT) (>= v0.17.0)
+ * @param {number} [opt.paddingRight=0] - right padding (default = 0) ($GUM_WRITE_PADDING_RIGHT) (>= v0.17.0)
+ * @param {number} [opt.paddingTop=0] - top padding (default = 0) ($GUM_WRITE_PADDING_TOP) (>= v0.17.0)
+ * @param {number} [opt.paddingBottom=0] - bottom padding (default = 0) ($GUM_WRITE_PADDING_BOTTOM) (>= v0.17.0)
  * @param {CustomOptions} [opt.custom]
  *
  * @returns {string|undefined}
  */
 export const write = (opt) => {
   opt = opt || {};
+
+  /*
+    We retrieve environment first because merging padding
+    values relies on those environment variables as fallback
+   */
+  const env = getEnv(opt.custom?.env, ['PADDING']);
+
   const cmdline = ['gum', 'write'];
   if (opt.header) {
     cmdline.push('--header', opt.header);
@@ -1508,8 +1849,21 @@ export const write = (opt) => {
     cmdline.push(`--show-line-numbers=${opt.showLineNumbers ? 'yes' : 'no'}`);
   }
 
-  addCustomArguments(cmdline, opt.custom?.args);
-  const env = getEnv(opt.custom?.env);
+  if (versionGte('0.17.0', opt?.custom?.dryRunVersion)) {
+    cmdline.push(
+      '--padding',
+      mergePaddingValues(
+        env,
+        opt.paddingTop,
+        opt.paddingRight,
+        opt.paddingBottom,
+        opt.paddingLeft,
+        'GUM_WRITE_'
+      )
+    );
+  }
+
+  addCustomArguments(cmdline, opt.custom?.args, ['--padding']);
 
   if (opt.custom?.dryRunCb) {
     opt.custom.dryRunCb(cmdline, env);
@@ -1660,6 +2014,11 @@ export const join = (text, opt) => {
   return output;
 };
 
+const PAGER_DEFAULT_PADDING_LEFT = 0;
+const PAGER_DEFAULT_PADDING_RIGHT = 0;
+const PAGER_DEFAULT_PADDING_TOP = 0;
+const PAGER_DEFAULT_PADDING_BOTTOM = 0;
+
 /**
  * Scroll through content
  *
@@ -1669,20 +2028,45 @@ export const join = (text, opt) => {
  * @param {object} [opt] - options
  * @param {boolean} [opt.showLineNumbers=true] - show line numbers (default = true)
  * @param {boolean} [opt.softWrap=false] - soft wrap lines (default = false)
+ * @param {number} [opt.paddingLeft=0] - left padding (default = 0) ($GUM_PAGER_PADDING_LEFT) (>= v0.17.0)
+ * @param {number} [opt.paddingRight=0] - right padding (default = 0) ($GUM_PAGER_PADDING_RIGHT) (>= v0.17.0)
+ * @param {number} [opt.paddingTop=0] - top padding (default = 0) ($GUM_PAGER_PADDING_TOP) (>= v0.17.0)
+ * @param {number} [opt.paddingBottom=0] - bottom padding (default = 0) ($GUM_PAGER_PADDING_BOTTOM) (>= v0.17.0)
  * @param {CustomOptions} [opt.custom]
  */
 export const pager = (content, opt) => {
   opt = opt || {};
+
+  /*
+    We retrieve environment first because merging padding
+    values relies on those environment variables as fallback
+   */
+  const baseEnv = getEnv(opt.custom?.env, ['PADDING']);
+
   const cmdline = ['gum', 'pager', content];
   cmdline.push(
     `--show-line-numbers=${opt.showLineNumbers !== false ? 'yes' : 'no'}`
   );
   cmdline.push(`--soft-wrap=${opt.softWrap ? 'yes' : 'no'}`);
 
-  addCustomArguments(cmdline, opt.custom?.args);
+  if (versionGte('0.17.0', opt?.custom?.dryRunVersion)) {
+    cmdline.push(
+      '--padding',
+      mergePaddingValues(
+        baseEnv,
+        opt.paddingTop,
+        opt.paddingRight,
+        opt.paddingBottom,
+        opt.paddingLeft,
+        'GUM_PAGER_'
+      )
+    );
+  }
+
+  addCustomArguments(cmdline, opt.custom?.args, ['--padding']);
   const env = {
     ...std.getenviron(),
-    ...getEnv(opt.custom?.env),
+    ...baseEnv,
   };
 
   if (opt.custom?.dryRunCb) {
@@ -1714,6 +2098,14 @@ defaultEnvironment['GUM_CHOOSE_SELECTED_PREFIX'] =
 defaultEnvironment['GUM_CHOOSE_UNSELECTED_PREFIX'] =
   CHOOSE_DEFAULT_UNSELECTED_PREFIX;
 defaultEnvironment['GUM_CHOOSE_ORDERED'] = CHOOSE_DEFAULT_ORDERED;
+defaultEnvironment['GUM_CHOOSE_PADDING_LEFT'] =
+  CHOOSE_DEFAULT_PADDING_LEFT.toString();
+defaultEnvironment['GUM_CHOOSE_PADDING_RIGHT'] =
+  CHOOSE_DEFAULT_PADDING_RIGHT.toString();
+defaultEnvironment['GUM_CHOOSE_PADDING_TOP'] =
+  CHOOSE_DEFAULT_PADDING_TOP.toString();
+defaultEnvironment['GUM_CHOOSE_PADDING_BOTTOM'] =
+  CHOOSE_DEFAULT_PADDING_BOTTOM.toString();
 
 // filter
 defaultEnvironment['GUM_FILTER_HEIGHT'] = FILTER_DEFAULT_HEIGHT.toString();
@@ -1728,21 +2120,73 @@ defaultEnvironment['GUM_FILTER_UNSELECTED_PREFIX'] =
 defaultEnvironment['GUM_FILTER_FUZZY'] = FILTER_DEFAULT_FUZZY;
 defaultEnvironment['GUM_FILTER_SORT'] = FILTER_DEFAULT_SORT;
 defaultEnvironment['GUM_FILTER_REVERSE'] = FILTER_DEFAULT_REVERSE;
+defaultEnvironment['GUM_FILTER_PADDING_LEFT'] =
+  FILTER_DEFAULT_PADDING_LEFT.toString();
+defaultEnvironment['GUM_FILTER_PADDING_RIGHT'] =
+  FILTER_DEFAULT_PADDING_RIGHT.toString();
+defaultEnvironment['GUM_FILTER_PADDING_TOP'] =
+  FILTER_DEFAULT_PADDING_TOP.toString();
+defaultEnvironment['GUM_FILTER_PADDING_BOTTOM'] =
+  FILTER_DEFAULT_PADDING_BOTTOM.toString();
+
+// table
+defaultEnvironment['GUM_TABLE_PADDING_LEFT'] =
+  TABLE_DEFAULT_PADDING_LEFT.toString();
+defaultEnvironment['GUM_TABLE_PADDING_RIGHT'] =
+  TABLE_DEFAULT_PADDING_RIGHT.toString();
+defaultEnvironment['GUM_TABLE_PADDING_TOP'] =
+  TABLE_DEFAULT_PADDING_TOP.toString();
+defaultEnvironment['GUM_TABLE_PADDING_BOTTOM'] =
+  TABLE_DEFAULT_PADDING_BOTTOM.toString();
+
+// confirm
+defaultEnvironment['GUM_CONFIRM_PADDING_LEFT'] =
+  CONFIRM_DEFAULT_PADDING_LEFT.toString();
+defaultEnvironment['GUM_CONFIRM_PADDING_RIGHT'] =
+  CONFIRM_DEFAULT_PADDING_RIGHT.toString();
+defaultEnvironment['GUM_CONFIRM_PADDING_TOP'] =
+  CONFIRM_DEFAULT_PADDING_TOP.toString();
+defaultEnvironment['GUM_CONFIRM_PADDING_BOTTOM'] =
+  CONFIRM_DEFAULT_PADDING_BOTTOM.toString();
 
 // file
 defaultEnvironment['GUM_FILE_CURSOR'] = FILE_DEFAULT_CURSOR;
 defaultEnvironment['GUM_FILE_HEIGHT'] = FILE_DEFAULT_HEIGHT.toString();
+defaultEnvironment['GUM_FILE_PADDING_LEFT'] =
+  FILE_DEFAULT_PADDING_LEFT.toString();
+defaultEnvironment['GUM_FILE_PADDING_RIGHT'] =
+  FILE_DEFAULT_PADDING_RIGHT.toString();
+defaultEnvironment['GUM_FILE_PADDING_TOP'] =
+  FILE_DEFAULT_PADDING_TOP.toString();
+defaultEnvironment['GUM_FILE_PADDING_BOTTOM'] =
+  FILE_DEFAULT_PADDING_BOTTOM.toString();
 
 // spin
 defaultEnvironment['GUM_SPIN_TITLE'] = SPIN_DEFAULT_TITLE;
 defaultEnvironment['GUM_SPIN_SPINNER'] = SPIN_DEFAULT_SPINNER;
 defaultEnvironment['GUM_SPIN_ALIGN'] = SPIN_DEFAULT_ALIGN;
+defaultEnvironment['GUM_SPIN_PADDING_LEFT'] =
+  SPIN_DEFAULT_PADDING_LEFT.toString();
+defaultEnvironment['GUM_SPIN_PADDING_RIGHT'] =
+  SPIN_DEFAULT_PADDING_RIGHT.toString();
+defaultEnvironment['GUM_SPIN_PADDING_TOP'] =
+  SPIN_DEFAULT_PADDING_TOP.toString();
+defaultEnvironment['GUM_SPIN_PADDING_BOTTOM'] =
+  SPIN_DEFAULT_PADDING_BOTTOM.toString();
 
 // input
 defaultEnvironment['GUM_INPUT_CURSOR_MODE'] = INPUT_DEFAULT_CURSOR_MODE;
 defaultEnvironment['GUM_INPUT_PLACEHOLDER'] = INPUT_DEFAULT_PLACEHOLDER;
 defaultEnvironment['GUM_INPUT_PROMPT'] = INPUT_DEFAULT_PROMPT;
 defaultEnvironment['GUM_INPUT_WIDTH'] = INPUT_DEFAULT_WIDTH.toString();
+defaultEnvironment['GUM_INPUT_PADDING_LEFT'] =
+  INPUT_DEFAULT_PADDING_LEFT.toString();
+defaultEnvironment['GUM_INPUT_PADDING_RIGHT'] =
+  INPUT_DEFAULT_PADDING_RIGHT.toString();
+defaultEnvironment['GUM_INPUT_PADDING_TOP'] =
+  INPUT_DEFAULT_PADDING_TOP.toString();
+defaultEnvironment['GUM_INPUT_PADDING_BOTTOM'] =
+  INPUT_DEFAULT_PADDING_BOTTOM.toString();
 
 // write
 defaultEnvironment['GUM_WRITE_CURSOR_MODE'] = WRITE_DEFAULT_CURSOR_MODE;
@@ -1752,6 +2196,14 @@ defaultEnvironment['GUM_WRITE_WIDTH'] = WRITE_DEFAULT_WIDTH.toString();
 defaultEnvironment['GUM_WRITE_HEIGHT'] = WRITE_DEFAULT_HEIGHT.toString();
 defaultEnvironment['GUM_WRITE_SHOW_LINE_NUMBERS'] =
   WRITE_DEFAULT_SHOW_LINE_NUMBERS;
+defaultEnvironment['GUM_WRITE_PADDING_LEFT'] =
+  WRITE_DEFAULT_PADDING_LEFT.toString();
+defaultEnvironment['GUM_WRITE_PADDING_RIGHT'] =
+  WRITE_DEFAULT_PADDING_RIGHT.toString();
+defaultEnvironment['GUM_WRITE_PADDING_TOP'] =
+  WRITE_DEFAULT_PADDING_TOP.toString();
+defaultEnvironment['GUM_WRITE_PADDING_BOTTOM'] =
+  WRITE_DEFAULT_PADDING_BOTTOM.toString();
 
 // style
 defaultEnvironment['BORDER'] = STYLE_DEFAULT_BORDER;
@@ -1775,3 +2227,13 @@ defaultEnvironment['FAINT'] = STYLE_DEFAULT_FAINT;
 // format
 defaultEnvironment['GUM_FORMAT_TYPE'] = FORMAT_DEFAULT_TYPE;
 defaultEnvironment['GUM_FORMAT_THEME'] = FORMAT_DEFAULT_THEME;
+
+// pager
+defaultEnvironment['GUM_PAGER_PADDING_LEFT'] =
+  PAGER_DEFAULT_PADDING_LEFT.toString();
+defaultEnvironment['GUM_PAGER_PADDING_RIGHT'] =
+  PAGER_DEFAULT_PADDING_RIGHT.toString();
+defaultEnvironment['GUM_PAGER_PADDING_TOP'] =
+  PAGER_DEFAULT_PADDING_TOP.toString();
+defaultEnvironment['GUM_PAGER_PADDING_BOTTOM'] =
+  PAGER_DEFAULT_PADDING_BOTTOM.toString();

--- a/src/version.js
+++ b/src/version.js
@@ -10,7 +10,7 @@
   An exception will be thrown in case a non semver version is passed as argument
  */
 
-const VERSION = '0.15.4';
+const VERSION = '0.16.0';
 
 /**
  * Check whether or not a version is in semver format

--- a/test/tests/test.gum.js
+++ b/test/tests/test.gum.js
@@ -68,6 +68,7 @@ export default () => {
             GUM_CHOOSE_CURSOR: '> ',
           });
         },
+        dryRunVersion: '0.16.0',
       },
     });
   });
@@ -109,6 +110,46 @@ export default () => {
             GUM_CHOOSE_CURSOR: 'cursor-var',
           });
         },
+        dryRunVersion: '0.16.0',
+      },
+    });
+  });
+
+  tester.test('gum.chooseItemFromList (with padding options)', () => {
+    gum.chooseItemFromList(['a', 'b', 'c'], {
+      header: 'header',
+      selected: 'a',
+      cursor: '>>',
+      height: 100,
+      paddingLeft: 1,
+      paddingRight: 2,
+      paddingTop: 3,
+      paddingBottom: 4,
+      custom: {
+        dryRunCb: (cmdline, env) => {
+          cmdlineShouldMatch(cmdline, [
+            'gum',
+            'choose',
+            '--limit',
+            '1',
+            '--header',
+            'header',
+            '--selected',
+            'a',
+            '--cursor=>>',
+            '--height',
+            '100',
+            '--padding',
+            '3 2 4 1',
+          ]);
+          envShouldContain(env, {
+            GUM_CHOOSE_PADDING_LEFT: '0',
+            GUM_CHOOSE_PADDING_RIGHT: '0',
+            GUM_CHOOSE_PADDING_TOP: '0',
+            GUM_CHOOSE_PADDING_BOTTOM: '0',
+          });
+        },
+        dryRunVersion: '0.17.0',
       },
     });
   });
@@ -123,6 +164,7 @@ export default () => {
             GUM_CHOOSE_CURSOR: '> ',
           });
         },
+        dryRunVersion: '0.16.0',
       },
     });
   });
@@ -173,6 +215,49 @@ export default () => {
             GUM_CHOOSE_CURSOR: 'cursor-var',
           });
         },
+        dryRunVersion: '0.16.0',
+      },
+    });
+  });
+
+  tester.test('gum.chooseItemsFromList (with padding options)', () => {
+    gum.chooseItemsFromList(['a', 'b', 'c'], {
+      header: 'header',
+      selected: ['a', 'b'],
+      cursor: '>>',
+      height: 100,
+      limit: 50,
+      ordered: true,
+      paddingLeft: 1,
+      paddingRight: 2,
+      paddingTop: 3,
+      paddingBottom: 4,
+      custom: {
+        dryRunCb: (cmdline, env) => {
+          cmdlineShouldMatch(cmdline, [
+            'gum',
+            'choose',
+            '--header',
+            'header',
+            '--selected',
+            'a,b',
+            '--cursor=>>',
+            '--height',
+            '100',
+            '--limit',
+            '50',
+            '--ordered=yes',
+            '--padding',
+            '3 2 4 1',
+          ]);
+          envShouldContain(env, {
+            GUM_CHOOSE_PADDING_LEFT: '0',
+            GUM_CHOOSE_PADDING_RIGHT: '0',
+            GUM_CHOOSE_PADDING_TOP: '0',
+            GUM_CHOOSE_PADDING_BOTTOM: '0',
+          });
+        },
+        dryRunVersion: '0.17.0',
       },
     });
   });
@@ -192,6 +277,7 @@ export default () => {
             GUM_FILTER_HEIGHT: '50',
           });
         },
+        dryRunVersion: '0.16.0',
       },
     });
   });
@@ -256,6 +342,59 @@ export default () => {
             GUM_FILTER_HEIGHT: '101',
           });
         },
+        dryRunVersion: '0.16.0',
+      },
+    });
+  });
+
+  tester.test('gum.filterItemFromList (with padding options)', () => {
+    gum.filterItemFromList(['a', 'b', 'c'], {
+      header: 'header',
+      placeholder: 'this is a placeholder',
+      width: 100,
+      height: 100,
+      prompt: '>>',
+      value: 'a',
+      fuzzy: false,
+      reverse: true,
+      sort: false,
+      paddingLeft: 1,
+      paddingRight: 2,
+      paddingTop: 3,
+      paddingBottom: 4,
+      custom: {
+        dryRunCb: (cmdline, env) => {
+          cmdlineShouldMatch(cmdline, [
+            'gum',
+            'filter',
+            '--limit',
+            '1',
+            '--header',
+            'header',
+            '--placeholder',
+            'this is a placeholder',
+            '--width',
+            '100',
+            '--height',
+            '100',
+            '--prompt',
+            '>>',
+            '--value',
+            'a',
+            '--no-fuzzy',
+            '--no-sort',
+            '--reverse=yes',
+            '--padding',
+            '3 2 4 1',
+          ]);
+          envShouldContain(env, {
+            GUM_FILTER_PADDING_LEFT: '0',
+            GUM_FILTER_PADDING_RIGHT: '0',
+            GUM_FILTER_PADDING_TOP: '0',
+            GUM_FILTER_PADDING_BOTTOM: '0',
+          });
+        },
+        dryRunVersion: '0.17.0',
       },
     });
   });
@@ -278,6 +417,7 @@ export default () => {
             GUM_FILTER_HEIGHT: '50',
           });
         },
+        dryRunVersion: '0.16.0',
       },
     });
   });
@@ -347,6 +487,58 @@ export default () => {
             GUM_FILTER_UNSELECTED_PREFIX: 'unselected-prefix-var',
           });
         },
+        dryRunVersion: '0.16.0',
+      },
+    });
+  });
+
+  tester.test('gum.filterItemsFromList (with padding options)', () => {
+    gum.filterItemsFromList(['a', 'b', 'c'], {
+      header: 'header',
+      placeholder: 'this is a placeholder',
+      width: 100,
+      height: 100,
+      prompt: '>>',
+      value: 'a',
+      fuzzy: false,
+      reverse: true,
+      sort: false,
+      paddingLeft: 1,
+      paddingRight: 2,
+      paddingTop: 3,
+      paddingBottom: 4,
+      custom: {
+        dryRunCb: (cmdline, env) => {
+          cmdlineShouldMatch(cmdline, [
+            'gum',
+            'filter',
+            '--header',
+            'header',
+            '--placeholder',
+            'this is a placeholder',
+            '--width',
+            '100',
+            '--height',
+            '100',
+            '--prompt',
+            '>>',
+            '--value',
+            'a',
+            '--no-fuzzy',
+            '--no-sort',
+            '--reverse=yes',
+            '--no-limit',
+            '--padding',
+            '3 2 4 1',
+          ]);
+          envShouldContain(env, {
+            GUM_FILTER_PADDING_LEFT: '0',
+            GUM_FILTER_PADDING_RIGHT: '0',
+            GUM_FILTER_PADDING_TOP: '0',
+            GUM_FILTER_PADDING_BOTTOM: '0',
+          });
+        },
+        dryRunVersion: '0.17.0',
       },
     });
   });
@@ -571,6 +763,7 @@ export default () => {
               'rounded',
             ]);
           },
+          dryRunVersion: '0.16.0',
         },
       }
     );
@@ -607,6 +800,51 @@ export default () => {
               'extra-arg',
             ]);
           },
+          dryRunVersion: '0.16.0',
+        },
+      }
+    );
+  });
+
+  tester.test('gum.renderTable (with padding options)', () => {
+    gum.renderTable(
+      ['col1', 'col2', 'col3'],
+      [
+        ['a1', 'b1', 'c1'],
+        ['a2', 'b2', 'c2'],
+      ],
+      {
+        border: gum.Border.DOUBLE,
+        widths: [10, 20, 30],
+        paddingLeft: 1,
+        paddingRight: 2,
+        paddingTop: 3,
+        paddingBottom: 4,
+        custom: {
+          dryRunCb: (cmdline, env) => {
+            cmdlineShouldMatch(cmdline, [
+              'gum',
+              'table',
+              '--print',
+              '--separator',
+              ',',
+              '--columns',
+              'col1,col2,col3',
+              '--border',
+              'double',
+              '--widths',
+              '10,20,30',
+              '--padding',
+              '3 2 4 1',
+            ]);
+            envShouldContain(env, {
+              GUM_TABLE_PADDING_LEFT: '0',
+              GUM_TABLE_PADDING_RIGHT: '0',
+              GUM_TABLE_PADDING_TOP: '0',
+              GUM_TABLE_PADDING_BOTTOM: '0',
+            });
+          },
+          dryRunVersion: '0.17.0',
         },
       }
     );
@@ -635,6 +873,7 @@ export default () => {
               '4,4,4',
             ]);
           },
+          dryRunVersion: '0.16.0',
         },
       }
     );
@@ -670,6 +909,50 @@ export default () => {
               'extra-arg',
             ]);
           },
+          dryRunVersion: '0.16.0',
+        },
+      }
+    );
+  });
+
+  tester.test('gum.chooseRowFromTable (with padding options)', () => {
+    gum.chooseRowFromTable(
+      ['col1', 'col2', 'col3'],
+      [
+        ['a1', 'b1', 'c1'],
+        ['a2', 'b2', 'c2'],
+      ],
+      {
+        height: 100,
+        widths: [10, 20, 30],
+        paddingLeft: 1,
+        paddingRight: 2,
+        paddingTop: 3,
+        paddingBottom: 4,
+        custom: {
+          dryRunCb: (cmdline, env) => {
+            cmdlineShouldMatch(cmdline, [
+              'gum',
+              'table',
+              '--separator',
+              ',',
+              '--columns',
+              'col1,col2,col3',
+              '--height',
+              '100',
+              '--widths',
+              '10,20,30',
+              '--padding',
+              '3 2 4 1',
+            ]);
+            envShouldContain(env, {
+              GUM_TABLE_PADDING_LEFT: '0',
+              GUM_TABLE_PADDING_RIGHT: '0',
+              GUM_TABLE_PADDING_TOP: '0',
+              GUM_TABLE_PADDING_BOTTOM: '0',
+            });
+          },
+          dryRunVersion: '0.17.0',
         },
       }
     );
@@ -690,6 +973,7 @@ export default () => {
             'Are you sure?',
           ]);
         },
+        dryRunVersion: '0.16.0',
       },
     });
   });
@@ -718,6 +1002,43 @@ export default () => {
             'extra-arg',
           ]);
         },
+        dryRunVersion: '0.16.0',
+      },
+    });
+  });
+
+  tester.test('gum.confirm (with padding options)', () => {
+    gum.confirm({
+      prompt: 'Are you really sure?',
+      affirmative: 'Yes!',
+      negative: 'No!',
+      default: 'no',
+      paddingLeft: 1,
+      paddingRight: 2,
+      paddingTop: 3,
+      paddingBottom: 4,
+      custom: {
+        dryRunCb: (cmdline, env) => {
+          cmdlineShouldMatch(cmdline, [
+            'gum',
+            'confirm',
+            '--default=no',
+            '--affirmative',
+            'Yes!',
+            '--negative',
+            'No!',
+            'Are you really sure?',
+            '--padding',
+            '3 2 4 1',
+          ]);
+          envShouldContain(env, {
+            GUM_CONFIRM_PADDING_LEFT: '0',
+            GUM_CONFIRM_PADDING_RIGHT: '0',
+            GUM_CONFIRM_PADDING_TOP: '0',
+            GUM_CONFIRM_PADDING_BOTTOM: '0',
+          });
+        },
+        dryRunVersion: '0.17.0',
       },
     });
   });
@@ -737,6 +1058,7 @@ export default () => {
             GUM_FILE_HEIGHT: '50',
           });
         },
+        dryRunVersion: '0.16.0',
       },
     });
   });
@@ -774,6 +1096,44 @@ export default () => {
             GUM_FILE_HEIGHT: '101',
           });
         },
+        dryRunVersion: '0.16.0',
+      },
+    });
+  });
+
+  tester.test('gum.chooseFile (with padding options)', () => {
+    gum.chooseFile({
+      path: '/tmp',
+      cursor: '>>',
+      height: 100,
+      all: true,
+      paddingLeft: 1,
+      paddingRight: 2,
+      paddingTop: 3,
+      paddingBottom: 4,
+      custom: {
+        dryRunCb: (cmdline, env) => {
+          cmdlineShouldMatch(cmdline, [
+            'gum',
+            'file',
+            '--file=true',
+            '--directory=false',
+            '--cursor=>>',
+            '--all',
+            '--height',
+            '100',
+            '/tmp',
+            '--padding',
+            '3 2 4 1',
+          ]);
+          envShouldContain(env, {
+            GUM_FILE_PADDING_LEFT: '0',
+            GUM_FILE_PADDING_RIGHT: '0',
+            GUM_FILE_PADDING_TOP: '0',
+            GUM_FILE_PADDING_BOTTOM: '0',
+          });
+        },
+        dryRunVersion: '0.17.0',
       },
     });
   });
@@ -793,6 +1153,7 @@ export default () => {
             GUM_FILE_HEIGHT: '50',
           });
         },
+        dryRunVersion: '0.16.0',
       },
     });
   });
@@ -830,6 +1191,44 @@ export default () => {
             GUM_FILE_HEIGHT: '101',
           });
         },
+        dryRunVersion: '0.16.0',
+      },
+    });
+  });
+
+  tester.test('gum.chooseDirectory (with padding options)', () => {
+    gum.chooseDirectory({
+      path: '/tmp',
+      cursor: '>>',
+      height: 100,
+      all: true,
+      paddingLeft: 1,
+      paddingRight: 2,
+      paddingTop: 3,
+      paddingBottom: 4,
+      custom: {
+        dryRunCb: (cmdline, env) => {
+          cmdlineShouldMatch(cmdline, [
+            'gum',
+            'file',
+            '--file=false',
+            '--directory=true',
+            '--cursor=>>',
+            '--all',
+            '--height',
+            '100',
+            '/tmp',
+            '--padding',
+            '3 2 4 1',
+          ]);
+          envShouldContain(env, {
+            GUM_FILE_PADDING_LEFT: '0',
+            GUM_FILE_PADDING_RIGHT: '0',
+            GUM_FILE_PADDING_TOP: '0',
+            GUM_FILE_PADDING_BOTTOM: '0',
+          });
+        },
+        dryRunVersion: '0.17.0',
       },
     });
   });
@@ -915,6 +1314,45 @@ export default () => {
     });
   });
 
+  tester.test('gum.spin (with padding options)', () => {
+    gum.spin(Promise.resolve(), {
+      title: 'Loading, please wait...',
+      spinner: gum.Spinner.GLOBE,
+      align: gum.Align.RIGHT,
+      paddingLeft: 1,
+      paddingRight: 2,
+      paddingTop: 3,
+      paddingBottom: 4,
+      custom: {
+        dryRunCb: (cmdline, env) => {
+          cmdlineShouldMatch(cmdline, [
+            'gum',
+            'spin',
+            '--show-stdout',
+            '--title',
+            'Loading, please wait...',
+            '--spinner',
+            gum.Spinner.GLOBE,
+            '--align',
+            gum.Align.RIGHT,
+            '--padding',
+            '3 2 4 1',
+            '--',
+            'tail',
+            '-1',
+          ]);
+          envShouldContain(env, {
+            GUM_SPIN_PADDING_LEFT: '0',
+            GUM_SPIN_PADDING_RIGHT: '0',
+            GUM_SPIN_PADDING_TOP: '0',
+            GUM_SPIN_PADDING_BOTTOM: '0',
+          });
+        },
+        dryRunVersion: '0.17.0',
+      },
+    });
+  });
+
   tester.test('gum.input (without options)', () => {
     gum.input({
       custom: {
@@ -927,6 +1365,7 @@ export default () => {
             GUM_INPUT_PROMPT: '> ',
           });
         },
+        dryRunVersion: '0.16.0',
       },
     });
   });
@@ -980,6 +1419,56 @@ export default () => {
             GUM_INPUT_PROMPT: 'prompt-var',
           });
         },
+        dryRunVersion: '0.16.0',
+      },
+    });
+  });
+
+  tester.test('gum.input (with padding options)', () => {
+    gum.input({
+      header: 'header',
+      placeholder: 'this is a placeholder',
+      cursorMode: gum.CursorMode.STATIC,
+      prompt: '>>',
+      charLimit: 401,
+      width: 100,
+      value: 'initial value',
+      password: true,
+      paddingLeft: 1,
+      paddingRight: 2,
+      paddingTop: 3,
+      paddingBottom: 4,
+      custom: {
+        dryRunCb: (cmdline, env) => {
+          cmdlineShouldMatch(cmdline, [
+            'gum',
+            'input',
+            '--header',
+            'header',
+            '--placeholder',
+            'this is a placeholder',
+            '--prompt',
+            '>>',
+            '--value',
+            'initial value',
+            '--password',
+            '--char-limit',
+            '401',
+            '--width',
+            '100',
+            '--cursor.mode',
+            'static',
+            '--padding',
+            '3 2 4 1',
+          ]);
+          envShouldContain(env, {
+            GUM_INPUT_PADDING_LEFT: '0',
+            GUM_INPUT_PADDING_RIGHT: '0',
+            GUM_INPUT_PADDING_TOP: '0',
+            GUM_INPUT_PADDING_BOTTOM: '0',
+          });
+        },
+        dryRunVersion: '0.17.0',
       },
     });
   });
@@ -998,6 +1487,7 @@ export default () => {
             GUM_WRITE_SHOW_LINE_NUMBERS: 'no',
           });
         },
+        dryRunVersion: '0.16.0',
       },
     });
   });
@@ -1055,6 +1545,56 @@ export default () => {
             GUM_WRITE_SHOW_LINE_NUMBERS: 'no-var',
           });
         },
+        dryRunVersion: '0.16.0',
+      },
+    });
+  });
+
+  tester.test('gum.write (with padding options)', () => {
+    gum.write({
+      header: 'header',
+      placeholder: 'this is a placeholder',
+      cursorMode: gum.CursorMode.STATIC,
+      prompt: '>>',
+      charLimit: 401,
+      width: 100,
+      height: 100,
+      showLineNumbers: true,
+      paddingLeft: 1,
+      paddingRight: 2,
+      paddingTop: 3,
+      paddingBottom: 4,
+      custom: {
+        dryRunCb: (cmdline, env) => {
+          cmdlineShouldMatch(cmdline, [
+            'gum',
+            'write',
+            '--header',
+            'header',
+            '--placeholder',
+            'this is a placeholder',
+            '--prompt',
+            '>>',
+            '--char-limit',
+            '401',
+            '--width',
+            '100',
+            '--height',
+            '100',
+            '--cursor.mode',
+            'static',
+            '--show-line-numbers=yes',
+            '--padding',
+            '3 2 4 1',
+          ]);
+          envShouldContain(env, {
+            GUM_WRITE_PADDING_LEFT: '0',
+            GUM_WRITE_PADDING_RIGHT: '0',
+            GUM_WRITE_PADDING_TOP: '0',
+            GUM_WRITE_PADDING_BOTTOM: '0',
+          });
+        },
+        dryRunVersion: '0.17.0',
       },
     });
   });
@@ -1167,6 +1707,7 @@ export default () => {
             '--soft-wrap=no',
           ]);
         },
+        dryRunVersion: '0.16.0',
       },
     });
   });
@@ -1190,6 +1731,38 @@ export default () => {
             'extra-arg',
           ]);
         },
+        dryRunVersion: '0.16.0',
+      },
+    });
+  });
+
+  tester.test('gum.pager (with padding options)', () => {
+    gum.pager('content', {
+      showLineNumbers: false,
+      softWrap: true,
+      paddingLeft: 1,
+      paddingRight: 2,
+      paddingTop: 3,
+      paddingBottom: 4,
+      custom: {
+        dryRunCb: (cmdline, env) => {
+          cmdlineShouldMatch(cmdline, [
+            'gum',
+            'pager',
+            'content',
+            '--show-line-numbers=no',
+            '--soft-wrap=yes',
+            '--padding',
+            '3 2 4 1',
+          ]);
+          envShouldContain(env, {
+            GUM_PAGER_PADDING_LEFT: '0',
+            GUM_PAGER_PADDING_RIGHT: '0',
+            GUM_PAGER_PADDING_TOP: '0',
+            GUM_PAGER_PADDING_BOTTOM: '0',
+          });
+        },
+        dryRunVersion: '0.17.0',
       },
     });
   });

--- a/test/tests/test.process.js
+++ b/test/tests/test.process.js
@@ -29,7 +29,9 @@ export default () => {
       const opt = { trim: false };
       const cmdline = 'data/test1.sh 10';
       const p = new Process(cmdline, opt);
+      /** @type {string[]} */
       const stdoutLines = [];
+      /** @type {string[]} */
       const stderrLines = [];
       let stateFromEvent;
       let expectedContent, content, match;
@@ -98,6 +100,7 @@ export default () => {
       const opt = { trim: false };
       const cmdline = 'data/test1.sh 10';
       const p = new Process(cmdline, opt);
+      /** @type {string[]} */
       const stdoutLines = [];
       let expectedContent, content, match;
       p.setEventListener('stdout', (obj) => {
@@ -138,6 +141,7 @@ export default () => {
       const opt = { trim: false };
       const cmdline = 'data/test1.sh 10';
       const p = new Process(cmdline, opt);
+      /** @type {string[]} */
       const stderrLines = [];
       let expectedContent, content;
       p.setEventListener('stderr', (obj) => {
@@ -223,7 +227,10 @@ export default () => {
     'process.Process (line buffering)',
     async (done) => {
       let opt, cmdline, p;
-      let stdoutLines, stderrLines;
+      /** @type {string[]} */
+      let stdoutLines;
+      /** @type {string[]} */
+      let stderrLines;
       let expectedContent, content;
 
       /*
@@ -700,6 +707,7 @@ export default () => {
     'process.Process (pause/resume)',
     async (done) => {
       let opt, cmdline, p;
+      /** @type {string[]} */
       let stdoutLines = [];
       let content, finalContent;
 
@@ -924,7 +932,7 @@ export default () => {
       cmdline = 'data/test1.sh 10 2';
       try {
         await exec(cmdline, opt);
-      } catch (e) {
+      } catch (/** @type {any} */ e) {
         expectedContent = `1\n3\n5\n7\n9`;
         content = e.message;
         tester.assertEq(
@@ -1388,7 +1396,7 @@ export default () => {
     cmdline = 'data/test1.sh 10 2';
     try {
       execSync(cmdline, opt);
-    } catch (e) {
+    } catch (/** @type {any} */ e) {
       expectedContent = `1\n3\n5\n7\n9`;
       content = e.message;
       tester.assertEq(


### PR DESCRIPTION
## [0.16.0]
* feat: add support for [gum](https://github.com/charmbracelet/gum) version (`v0.17.0`) (`gum.js`)
* refactor: use [gum](https://github.com/charmbracelet/gum) version (`v0.17.0`) in bootstrap
